### PR TITLE
Lägg till Live Voice+Vision WS med Gemini Live och gateway för tool-calls

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -12,6 +12,20 @@ class Settings(BaseSettings):
     # API Keys
     GOOGLE_API_KEY: Optional[str] = None
     OPENAI_API_KEY: Optional[str] = None
+
+    # Live voice + vision settings
+    GEMINI_LIVE_MODEL: str = "gemini-2.5-flash-native-audio-preview-09-2025"
+    LIVE_FRAME_FPS: float = 1.0
+    LIVE_AUDIO_CHUNK_MS: int = 30
+
+    # External tool gateway settings
+    OPENCLOW_SCHEME: str = "http"
+    OPENCLOW_HOST: Optional[str] = None
+    OPENCLOW_PORT: Optional[int] = None
+    OPENCLOW_PATH: str = "/execute"
+    OPENCLOW_TOKEN: Optional[str] = None
+    OPENCLOW_TIMEOUT_SECONDS: float = 12.0
+    OPENCLOW_RETRIES: int = 1
     
     # Mem0 / Vector DB
     MEM0_API_KEY: Optional[str] = None

--- a/app/routers/live.py
+++ b/app/routers/live.py
@@ -1,0 +1,63 @@
+"""WebSocket route for Freja live voice + vision streaming."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from app.core.logging import logger
+from app.services.gemini_live_session import GeminiLiveSession
+
+router = APIRouter()
+
+
+@router.websocket("/ws/live")
+async def live_ws(websocket: WebSocket) -> None:
+    """Bidirectional bridge between browser media events and Gemini Live responses."""
+    await websocket.accept()
+    logger.info("Live WS client connected")
+
+    async def send_event(payload: dict[str, Any]) -> None:
+        # Standardized JSON envelope sent to the browser for all downstream events.
+        await websocket.send_text(json.dumps(payload))
+
+    session: GeminiLiveSession | None = None
+
+    try:
+        session = GeminiLiveSession(on_downstream_event=send_event)
+        await session.start()
+
+        while True:
+            raw = await websocket.receive_text()
+            event = json.loads(raw)
+            event_type = event.get("type")
+
+            if event_type == "audio_chunk_up":
+                audio_payload = event.get("audio", "")
+                if audio_payload:
+                    await session.send_audio_chunk(audio_payload)
+            elif event_type == "video_frame_up":
+                frame_payload = event.get("image", "")
+                if frame_payload:
+                    await session.send_video_frame(frame_payload)
+            elif event_type == "ping":
+                await send_event({"type": "pong"})
+            else:
+                await send_event({"type": "status", "status": "unknown_event", "event": event_type})
+    except WebSocketDisconnect:
+        logger.info("Live WS client disconnected")
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Live WS error: %s", exc, exc_info=True)
+        try:
+            await websocket.send_text(json.dumps({"type": "error", "message": str(exc)}))
+        except Exception:  # noqa: BLE001
+            pass
+    finally:
+        if session:
+            await session.stop()
+        try:
+            await websocket.close()
+        except Exception:  # noqa: BLE001
+            pass

--- a/app/services/gemini_live_session.py
+++ b/app/services/gemini_live_session.py
@@ -1,0 +1,218 @@
+"""Bridge between Freja WebSocket clients and Gemini Live API sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections import deque
+from typing import Any, Awaitable, Callable
+
+from google import genai
+from google.genai import types
+
+from app.core.config import settings
+from app.core.logging import logger
+from app.services.tool_call_router import ToolCallRouter
+
+DownstreamCallback = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+class GeminiLiveSession:
+    """Maintains one Gemini Live websocket session and forwards audio/video + tool events."""
+
+    def __init__(self, *, on_downstream_event: DownstreamCallback) -> None:
+        # API key is loaded from server config only to avoid key leakage to the frontend.
+        if not settings.GOOGLE_API_KEY:
+            raise ValueError("GOOGLE_API_KEY is missing on backend")
+
+        self.client = genai.Client(api_key=settings.GOOGLE_API_KEY, http_options={"api_version": "v1alpha"})
+        self.model = settings.GEMINI_LIVE_MODEL
+        self.on_downstream_event = on_downstream_event
+        self.tool_router = ToolCallRouter()
+
+        # Bounded queues provide basic backpressure for incoming media streams.
+        self._audio_queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=64)
+        self._video_queue: deque[bytes] = deque(maxlen=2)
+
+        self._session_cm: Any = None
+        self._session: Any = None
+        self._running = False
+        self._send_tasks: list[asyncio.Task[Any]] = []
+        self._receive_task: asyncio.Task[Any] | None = None
+
+    async def start(self) -> None:
+        """Open Gemini Live session and start background sender/receiver loops."""
+        tools = [
+            types.Tool(
+                function_declarations=[
+                    types.FunctionDeclaration(
+                        name="gateway_execute",
+                        description="Execute an external action through Freja gateway.",
+                        parameters=types.Schema(
+                            type=types.Type.OBJECT,
+                            properties={
+                                "action": types.Schema(type=types.Type.STRING, description="Action/tool name"),
+                                "arguments": types.Schema(type=types.Type.OBJECT, description="Action arguments"),
+                            },
+                            required=["action"],
+                        ),
+                    )
+                ]
+            )
+        ]
+
+        # Response modalities include both text and audio for parity with VisionClaw-like behavior.
+        live_config = {
+            "response_modalities": ["AUDIO", "TEXT"],
+            "tools": tools,
+            "system_instruction": "You are Freja. Always answer in Swedish.",
+        }
+
+        self._session_cm = self.client.aio.live.connect(model=self.model, config=live_config)
+        self._session = await self._session_cm.__aenter__()
+        self._running = True
+
+        await self.on_downstream_event({"type": "status", "status": "connected", "model": self.model})
+        logger.info("Gemini live session connected (model=%s)", self.model)
+
+        self._send_tasks = [
+            asyncio.create_task(self._audio_sender_loop(), name="gemini-live-audio-sender"),
+            asyncio.create_task(self._video_sender_loop(), name="gemini-live-video-sender"),
+        ]
+        self._receive_task = asyncio.create_task(self._receive_loop(), name="gemini-live-receive")
+
+    async def stop(self) -> None:
+        """Close all tasks and the upstream Gemini session safely."""
+        self._running = False
+
+        for task in self._send_tasks:
+            task.cancel()
+        self._send_tasks = []
+
+        if self._receive_task:
+            self._receive_task.cancel()
+            self._receive_task = None
+
+        if self._session_cm:
+            try:
+                await self._session_cm.__aexit__(None, None, None)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Error while closing Gemini live session: %s", exc)
+
+        self._session = None
+        await self.on_downstream_event({"type": "status", "status": "disconnected"})
+
+    async def send_audio_chunk(self, pcm16k_b64: str) -> None:
+        """Queue one upstream audio chunk (PCM16 mono 16kHz)."""
+        chunk = base64.b64decode(pcm16k_b64)
+        try:
+            self._audio_queue.put_nowait(chunk)
+        except asyncio.QueueFull:
+            # Drop oldest data under pressure to favor low-latency conversational behavior.
+            _ = self._audio_queue.get_nowait()
+            self._audio_queue.put_nowait(chunk)
+
+    async def send_video_frame(self, jpeg_b64: str) -> None:
+        """Store latest JPEG frame for ~1 FPS upstream vision updates."""
+        frame = base64.b64decode(jpeg_b64)
+        self._video_queue.append(frame)
+
+    async def _audio_sender_loop(self) -> None:
+        """Continuously forwards buffered audio chunks to Gemini Live realtime input."""
+        while self._running and self._session:
+            data = await self._audio_queue.get()
+            await self._session.send_realtime_input(
+                audio=types.Blob(data=data, mime_type="audio/pcm;rate=16000")
+            )
+
+    async def _video_sender_loop(self) -> None:
+        """Sends the latest buffered video frame, paced by configured frame rate."""
+        sleep_interval = 1.0 / max(settings.LIVE_FRAME_FPS, 0.1)
+        while self._running and self._session:
+            if self._video_queue:
+                latest = self._video_queue.pop()
+                self._video_queue.clear()
+                await self._session.send_realtime_input(
+                    video=types.Blob(data=latest, mime_type="image/jpeg")
+                )
+                await self.on_downstream_event({"type": "status", "status": "frame_sent"})
+            await asyncio.sleep(sleep_interval)
+
+    async def _receive_loop(self) -> None:
+        """Receives model events (audio/text/tool calls) and forwards them to frontend."""
+        assert self._session is not None
+        try:
+            async for response in self._session.receive():
+                # Handle explicit tool calls emitted by the model.
+                tool_call = getattr(response, "tool_call", None)
+                if tool_call and getattr(tool_call, "function_calls", None):
+                    await self._handle_tool_call(tool_call)
+
+                server_content = getattr(response, "server_content", None)
+                if not server_content:
+                    continue
+
+                model_turn = getattr(server_content, "model_turn", None)
+                if not model_turn:
+                    continue
+
+                for part in getattr(model_turn, "parts", []) or []:
+                    inline_data = getattr(part, "inline_data", None)
+                    text = getattr(part, "text", None)
+
+                    if inline_data and getattr(inline_data, "data", None):
+                        audio_b64 = base64.b64encode(inline_data.data).decode("utf-8")
+                        await self.on_downstream_event(
+                            {
+                                "type": "audio_chunk_down",
+                                "mime_type": getattr(inline_data, "mime_type", "audio/pcm;rate=24000"),
+                                "audio": audio_b64,
+                            }
+                        )
+
+                    if text:
+                        await self.on_downstream_event({"type": "transcript", "text": text})
+        except asyncio.CancelledError:
+            logger.debug("Gemini receive loop cancelled")
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Gemini receive loop error: %s", exc, exc_info=True)
+            await self.on_downstream_event({"type": "error", "message": str(exc)})
+
+    async def _handle_tool_call(self, tool_call: Any) -> None:
+        """Routes each tool call through HTTP gateway and returns result back to Gemini."""
+        function_responses: list[types.FunctionResponse] = []
+
+        for call in tool_call.function_calls:
+            action = call.args.get("action") if isinstance(call.args, dict) else None
+            arguments = call.args.get("arguments", {}) if isinstance(call.args, dict) else {}
+            action_name = action or call.name
+
+            await self.on_downstream_event(
+                {
+                    "type": "tool_call",
+                    "name": action_name,
+                    "args": arguments,
+                }
+            )
+
+            result = await self.tool_router.execute(action_name, arguments if isinstance(arguments, dict) else {})
+
+            await self.on_downstream_event(
+                {
+                    "type": "tool_result",
+                    "name": action_name,
+                    "result": result,
+                }
+            )
+
+            function_responses.append(
+                types.FunctionResponse(
+                    name=call.name,
+                    id=call.id,
+                    response={"result": result.get("text", "")},
+                )
+            )
+
+        if function_responses:
+            await self._session.send_tool_response(function_responses=function_responses)

--- a/app/services/tool_call_router.py
+++ b/app/services/tool_call_router.py
@@ -1,0 +1,96 @@
+"""Server-side tool call router for forwarding Gemini tool calls to an external gateway."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+from app.core.logging import logger
+
+
+class ToolCallRouter:
+    """Routes model tool calls to a configurable HTTP gateway with token auth."""
+
+    def __init__(self) -> None:
+        # The gateway host/port/token are read from server-side config only.
+        self.host = settings.OPENCLOW_HOST
+        self.port = settings.OPENCLOW_PORT
+        self.scheme = settings.OPENCLOW_SCHEME
+        self.path = settings.OPENCLOW_PATH
+        self.token = settings.OPENCLOW_TOKEN
+        self.timeout_seconds = settings.OPENCLOW_TIMEOUT_SECONDS
+        self.retries = settings.OPENCLOW_RETRIES
+
+    @property
+    def enabled(self) -> bool:
+        """Return True when minimum gateway settings are present."""
+        return bool(self.host and self.path)
+
+    @property
+    def execute_url(self) -> str:
+        """Build the target gateway URL from configured host/port/path."""
+        if self.port:
+            return f"{self.scheme}://{self.host}:{self.port}{self.path}"
+        return f"{self.scheme}://{self.host}{self.path}"
+
+    async def execute(self, tool_name: str, tool_args: dict[str, Any]) -> dict[str, Any]:
+        """
+        Forward a tool execution request to the gateway and return the normalized result.
+
+        If gateway configuration is missing, this falls back to a no-op result to keep
+        the Gemini session working during local smoke tests.
+        """
+        if not self.enabled:
+            logger.warning("Tool gateway disabled; returning no-op response for %s", tool_name)
+            return {
+                "ok": True,
+                "tool": tool_name,
+                "text": f"Tool gateway disabled. No-op executed for {tool_name}.",
+            }
+
+        payload = {
+            "tool": tool_name,
+            "arguments": tool_args,
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        last_error: Exception | None = None
+
+        for attempt in range(1, self.retries + 2):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+                    logger.info("Forwarding tool call %s to gateway (attempt %s)", tool_name, attempt)
+                    response = await client.post(self.execute_url, json=payload, headers=headers)
+                    response.raise_for_status()
+                    data = response.json()
+
+                # Normalize output for Gemini's tool response payload.
+                if isinstance(data, dict):
+                    if "text" in data:
+                        text = str(data.get("text"))
+                    elif "result" in data:
+                        text = str(data.get("result"))
+                    else:
+                        text = str(data)
+                    return {"ok": True, "tool": tool_name, "text": text, "raw": data}
+
+                return {"ok": True, "tool": tool_name, "text": str(data)}
+            except Exception as exc:  # noqa: BLE001 - broad exception to preserve session stability.
+                last_error = exc
+                logger.error("Gateway tool call failed (%s/%s): %s", attempt, self.retries + 1, exc)
+                if attempt <= self.retries:
+                    await asyncio.sleep(min(1.5 * attempt, 4.0))
+
+        return {
+            "ok": False,
+            "tool": tool_name,
+            "text": f"Gateway call failed for {tool_name}: {last_error}",
+        }

--- a/client/README.md
+++ b/client/README.md
@@ -6,3 +6,53 @@ Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Live Voice + Vision Smoke Test
+
+### 1) Backend environment
+
+Set these environment variables in backend `.env` before starting server:
+
+- `GOOGLE_API_KEY` (required, backend only)
+- `GEMINI_LIVE_MODEL` (optional, default in config)
+- `LIVE_FRAME_FPS` (optional, default `1.0`)
+- `OPENCLOW_SCHEME` (optional, default `http`)
+- `OPENCLOW_HOST` (optional, if missing tool calls become no-op)
+- `OPENCLOW_PORT` (optional)
+- `OPENCLOW_PATH` (optional, default `/execute`)
+- `OPENCLOW_TOKEN` (optional bearer token)
+
+### 2) Start backend and client
+
+Backend:
+
+```bash
+python main.py
+```
+
+Client:
+
+```bash
+cd client
+npm install
+npm run dev
+```
+
+### 3) Test without gateway (no-op tool calls)
+
+Leave `OPENCLOW_HOST` unset. Tool calls are acknowledged and return a no-op response so session keeps running.
+
+### 4) Test with gateway
+
+Set `OPENCLOW_HOST`/`OPENCLOW_PORT`/`OPENCLOW_TOKEN`, then verify gateway health manually:
+
+```bash
+curl -H "Authorization: Bearer $OPENCLOW_TOKEN" "http://$OPENCLOW_HOST:$OPENCLOW_PORT/health"
+```
+
+Then open Freja client, go to Voice view, click **Start Live Session**, and verify:
+
+- connected/streaming status changes to active
+- audio level updates while speaking
+- fps updates around configured value
+- tool activity displays call/result when model triggers tools

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import Dashboard from './components/Dashboard';
 import ChatInterface from './components/ChatInterface';
 import Settings from './components/Settings';
 import Prompts from './components/Prompts';
+import LiveSession from './components/LiveSession';
 
 import { useSocket } from './hooks/useSocket';
 
@@ -35,7 +36,7 @@ function App() {
                 {activeView === 'dashboard' && <Dashboard />}
                 {activeView === 'chat' && <ChatInterface />}
                 {activeView === 'prompts' && <Prompts />}
-                {activeView === 'voice' && <div className="p-8 text-2xl text-zinc-500">Voice Module Loading...</div>}
+                {activeView === 'voice' && <LiveSession />}
                 {activeView === 'settings' && <Settings />}
             </main>
         </div>

--- a/client/src/components/LiveSession.jsx
+++ b/client/src/components/LiveSession.jsx
@@ -1,0 +1,274 @@
+import { useEffect, useRef, useState } from 'react';
+import { API_URL } from '../config';
+
+const WS_URL = API_URL.replace(/^http/, 'ws');
+
+function floatTo16BitPCM(float32Array) {
+    const buffer = new ArrayBuffer(float32Array.length * 2);
+    const view = new DataView(buffer);
+    let offset = 0;
+    for (let i = 0; i < float32Array.length; i += 1) {
+        const s = Math.max(-1, Math.min(1, float32Array[i]));
+        view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+        offset += 2;
+    }
+    return new Uint8Array(buffer);
+}
+
+function base64FromBytes(bytes) {
+    let binary = '';
+    const chunk = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+    }
+    return btoa(binary);
+}
+
+function bytesFromBase64(base64) {
+    const bin = atob(base64);
+    const len = bin.length;
+    const arr = new Uint8Array(len);
+    for (let i = 0; i < len; i += 1) arr[i] = bin.charCodeAt(i);
+    return arr;
+}
+
+function LiveSession() {
+    const [connected, setConnected] = useState(false);
+    const [streaming, setStreaming] = useState(false);
+    const [cameraEnabled, setCameraEnabled] = useState(true);
+    const [status, setStatus] = useState('idle');
+    const [fps, setFps] = useState(0);
+    const [audioLevel, setAudioLevel] = useState(0);
+    const [toolActivity, setToolActivity] = useState('none');
+
+    const wsRef = useRef(null);
+    const micStreamRef = useRef(null);
+    const videoStreamRef = useRef(null);
+    const mediaRecorderRef = useRef(null);
+    const videoRef = useRef(null);
+    const canvasRef = useRef(null);
+
+    const audioContextRef = useRef(null);
+    const playbackQueueRef = useRef([]);
+    const isPlayingRef = useRef(false);
+
+    const frameIntervalRef = useRef(null);
+    const fpsCounterRef = useRef({ count: 0, timer: null });
+
+    const stopAll = () => {
+        setStreaming(false);
+        setConnected(false);
+        setStatus('stopped');
+
+        if (frameIntervalRef.current) {
+            clearInterval(frameIntervalRef.current);
+            frameIntervalRef.current = null;
+        }
+
+        if (fpsCounterRef.current.timer) {
+            clearInterval(fpsCounterRef.current.timer);
+            fpsCounterRef.current.timer = null;
+        }
+
+        if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+            mediaRecorderRef.current.stop();
+        }
+
+        if (micStreamRef.current) {
+            micStreamRef.current.getTracks().forEach((t) => t.stop());
+            micStreamRef.current = null;
+        }
+        if (videoStreamRef.current) {
+            videoStreamRef.current.getTracks().forEach((t) => t.stop());
+            videoStreamRef.current = null;
+        }
+
+        if (audioContextRef.current) {
+            audioContextRef.current.close();
+            audioContextRef.current = null;
+        }
+
+        if (wsRef.current) {
+            wsRef.current.close();
+            wsRef.current = null;
+        }
+    };
+
+    const playNext = async () => {
+        if (!audioContextRef.current || isPlayingRef.current || playbackQueueRef.current.length === 0) return;
+        isPlayingRef.current = true;
+
+        const bytes = playbackQueueRef.current.shift();
+        const samples = new Int16Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 2);
+        const floatData = new Float32Array(samples.length);
+        for (let i = 0; i < samples.length; i += 1) {
+            floatData[i] = samples[i] / 0x8000;
+        }
+
+        const sourceRate = 24000;
+        const targetRate = audioContextRef.current.sampleRate;
+        const ratio = sourceRate / targetRate;
+        const outLength = Math.floor(floatData.length / ratio);
+        const out = audioContextRef.current.createBuffer(1, outLength, targetRate);
+        const ch = out.getChannelData(0);
+        for (let i = 0; i < outLength; i += 1) {
+            ch[i] = floatData[Math.floor(i * ratio)] || 0;
+        }
+
+        const src = audioContextRef.current.createBufferSource();
+        src.buffer = out;
+        src.connect(audioContextRef.current.destination);
+        src.onended = () => {
+            isPlayingRef.current = false;
+            setTimeout(playNext, 0);
+        };
+        src.start();
+    };
+
+    const startSession = async () => {
+        try {
+            setStatus('starting');
+            audioContextRef.current = new (window.AudioContext || window.webkitAudioContext)();
+
+            const micStream = await navigator.mediaDevices.getUserMedia({
+                audio: {
+                    echoCancellation: true,
+                    noiseSuppression: true,
+                    autoGainControl: true,
+                    channelCount: 1,
+                },
+                video: false,
+            });
+            micStreamRef.current = micStream;
+
+            if (cameraEnabled) {
+                const camStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+                videoStreamRef.current = camStream;
+                if (videoRef.current) {
+                    videoRef.current.srcObject = camStream;
+                    await videoRef.current.play();
+                }
+            }
+
+            const ws = new WebSocket(`${WS_URL}/ws/live`);
+            wsRef.current = ws;
+
+            ws.onopen = () => {
+                setConnected(true);
+                setStreaming(true);
+                setStatus('connected');
+            };
+
+            ws.onmessage = (event) => {
+                const message = JSON.parse(event.data);
+                if (message.type === 'audio_chunk_down' && message.audio) {
+                    playbackQueueRef.current.push(bytesFromBase64(message.audio));
+                    playNext();
+                } else if (message.type === 'status') {
+                    setStatus(message.status || 'status');
+                } else if (message.type === 'transcript') {
+                    setStatus(`transcript: ${message.text}`);
+                } else if (message.type === 'tool_call') {
+                    setToolActivity(`call: ${message.name}`);
+                } else if (message.type === 'tool_result') {
+                    setToolActivity(`result: ${message.name}`);
+                } else if (message.type === 'error') {
+                    setStatus(`error: ${message.message}`);
+                }
+            };
+
+            ws.onerror = () => setStatus('ws_error');
+            ws.onclose = () => stopAll();
+
+            // Capture microphone audio using WebAudio and send 30ms PCM16 chunks.
+            const source = audioContextRef.current.createMediaStreamSource(micStream);
+            const processor = audioContextRef.current.createScriptProcessor(2048, 1, 1);
+            source.connect(processor);
+            processor.connect(audioContextRef.current.destination);
+
+            let sampleBucket = [];
+            processor.onaudioprocess = (e) => {
+                if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+                const input = e.inputBuffer.getChannelData(0);
+                const level = Math.min(1, input.reduce((a, v) => a + Math.abs(v), 0) / input.length * 3);
+                setAudioLevel(level);
+
+                const inRate = audioContextRef.current.sampleRate;
+                const outRate = 16000;
+                const ratio = inRate / outRate;
+                const resampledLength = Math.floor(input.length / ratio);
+                const resampled = new Float32Array(resampledLength);
+                for (let i = 0; i < resampledLength; i += 1) {
+                    resampled[i] = input[Math.floor(i * ratio)] || 0;
+                }
+
+                sampleBucket.push(...resampled);
+                const chunkSamples = Math.floor(outRate * 0.03);
+                while (sampleBucket.length >= chunkSamples) {
+                    const frame = new Float32Array(sampleBucket.slice(0, chunkSamples));
+                    sampleBucket = sampleBucket.slice(chunkSamples);
+                    const pcm = floatTo16BitPCM(frame);
+                    wsRef.current.send(JSON.stringify({ type: 'audio_chunk_up', audio: base64FromBytes(pcm) }));
+                }
+            };
+
+            // Send JPEG frames approximately once per second.
+            if (cameraEnabled) {
+                fpsCounterRef.current.count = 0;
+                fpsCounterRef.current.timer = setInterval(() => {
+                    setFps(fpsCounterRef.current.count);
+                    fpsCounterRef.current.count = 0;
+                }, 1000);
+
+                frameIntervalRef.current = setInterval(() => {
+                    if (!videoRef.current || !canvasRef.current || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+                    const video = videoRef.current;
+                    const canvas = canvasRef.current;
+                    const width = video.videoWidth || 640;
+                    const height = video.videoHeight || 360;
+                    canvas.width = width;
+                    canvas.height = height;
+                    const ctx = canvas.getContext('2d');
+                    ctx.drawImage(video, 0, 0, width, height);
+                    const jpgDataUrl = canvas.toDataURL('image/jpeg', 0.6);
+                    const image = jpgDataUrl.split(',')[1];
+                    wsRef.current.send(JSON.stringify({ type: 'video_frame_up', image, ts: Date.now() }));
+                    fpsCounterRef.current.count += 1;
+                }, 1000);
+            }
+        } catch (error) {
+            setStatus(`start_failed: ${error.message}`);
+            stopAll();
+        }
+    };
+
+    useEffect(() => () => stopAll(), []);
+
+    return (
+        <div className="p-8 space-y-6">
+            <h2 className="text-2xl font-bold">Live Voice + Vision</h2>
+
+            <div className="flex gap-3">
+                <button onClick={startSession} disabled={streaming} className="px-4 py-2 rounded bg-mainframe-accent text-black disabled:opacity-40">Start Live Session</button>
+                <button onClick={stopAll} disabled={!streaming} className="px-4 py-2 rounded bg-zinc-700 text-white disabled:opacity-40">Stop Live Session</button>
+                <button onClick={() => setCameraEnabled((v) => !v)} className="px-4 py-2 rounded bg-zinc-800 text-white">
+                    Camera: {cameraEnabled ? 'On' : 'Off'}
+                </button>
+            </div>
+
+            <div className="text-sm text-zinc-300 space-y-1">
+                <div>Connected: {connected ? 'yes' : 'no'}</div>
+                <div>Streaming: {streaming ? 'yes' : 'no'}</div>
+                <div>Status: {status}</div>
+                <div>FPS: {fps}</div>
+                <div>Audio level: {(audioLevel * 100).toFixed(0)}%</div>
+                <div>Tool activity: {toolActivity}</div>
+            </div>
+
+            <video ref={videoRef} className="w-full max-w-xl rounded border border-mainframe-border" muted playsInline />
+            <canvas ref={canvasRef} className="hidden" />
+        </div>
+    );
+}
+
+export default LiveSession;

--- a/main.py
+++ b/main.py
@@ -104,11 +104,12 @@ async def health_check():
     return {"status": "ok", "app": settings.APP_NAME}
 
 # Include API Routers
-from app.routers import chat, settings as settings_router, system
+from app.routers import chat, settings as settings_router, system, live
 
 app.include_router(chat.router)
 app.include_router(settings_router.router)
 app.include_router(system.router)
+app.include_router(live.router)
 
 # --- SERVE REACT FRONTEND (Production) ---
 from fastapi.staticfiles import StaticFiles


### PR DESCRIPTION
### Motivation
- Introduce real-time voice+vision sessions (mic + single-frame vision) backed by Gemini Live while keeping API keys strictly on the backend.
- Enable agentic/tool execution by forwarding model tool-calls to a configurable HTTP gateway with token auth and robust retry/timeout behavior.
- Provide a lightweight web “iPhone-mode” client that can run using the desktop camera/mic and show connection/streaming/tool status.

### Description
- Added backend configuration and environment-controlled settings in `app/core/config.py` for `GEMINI_LIVE_MODEL`, `LIVE_FRAME_FPS` and `OPENCLOW_*` gateway variables so secrets remain server-side.
- Implemented a server-side `GeminiLiveSession` in `app/services/gemini_live_session.py` that opens a Gemini Live session, queues upstream PCM16@16k audio and JPEG frames (~1 fps), receives audio/text downstream, and emits structured events (`audio_chunk_down`, `transcript`, `status`, `tool_call`, `tool_result`).
- Implemented `ToolCallRouter` in `app/services/tool_call_router.py` to POST tool execution requests to a configurable gateway with bearer token support, timeout, retry/backoff and a no-op fallback when gateway is not configured.
- Exposed a FastAPI WebSocket route `/ws/live` in `app/routers/live.py` that bridges browser JSON envelope messages to the `GeminiLiveSession` (protocol: `audio_chunk_up`, `video_frame_up`, `ping` → downstream events as above).
- Added a minimal web client component `client/src/components/LiveSession.jsx` and wired it into the app (`client/src/App.jsx`) that captures mic audio, resamples to 16k PCM16, chunks (≈30ms), sends base64 over WS, snapshots camera to JPEG ~1fps, plays back incoming PCM24 audio, shows status/fps/audio level/tool activity, and shuts down cleanly.
- Minor docs: updated `client/README.md` with smoke-test instructions and `main.py` includes the new router with minimal footprint to avoid changing unrelated features.

### Testing
- Ran Python compilation: `python -m compileall app main.py` — succeeded.
- Built frontend production bundle: `npm run build` (in `client/`) — succeeded.
- Launched dev frontend for smoke UI validation: `npm run dev -- --host 0.0.0.0 --port 4173` — dev server started and UI reachable.
- Automated UI check using Playwright to open the app and capture the Live view screenshot — script executed and screenshot captured successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d84427ae48333a8ef22c0d9fd00f7)