### PR TITLE
Ta bort kvarvarande Openclaw-referens

### DIFF
--- a/app/services/gemini_live_session.py
+++ b/app/services/gemini_live_session.py
@@ -61,7 +61,7 @@ class GeminiLiveSession:
             )
         ]
 
-        # Response modalities include both text and audio for parity with VisionClaw-like behavior.
+        # Response modalities include both text and audio for multimodal interaction parity.
         live_config = {
             "response_modalities": ["AUDIO", "TEXT"],
             "tools": tools,


### PR DESCRIPTION
### Motivation
- Ta bort kvarvarande referenser till Openclaw/VisionClaw i koden för att undvika oönskade beroenden eller referenser.

### Description
- Uppdaterade kommentaren i `app/services/gemini_live_session.py` för att ersätta VisionClaw-relaterad formulering med neutral text om multimodal interaktionsparitet.

### Testing
- Körda automatiska kontroller: sökning med `rg -n "Openclaw|openclaw|OPENCLAW|VisionClaw|visionclaw|claw|Claw" app client docs main.py` och `python -m compileall app main.py`, båda slutfördes utan fel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d861f36d883339a5087e3b0938465)