### PR TITLE
Add self-improving agent logging, hooks, scripts and tests

### DIFF
--- a/.learnings/ERRORS.md
+++ b/.learnings/ERRORS.md
@@ -1,0 +1,24 @@
+# Errors Log
+
+Structured logs for tool and runtime failures.
+
+## Entry Format
+
+Use this exact format for each entry:
+
+## ERR-YYYYMMDD-XXX - <Title>
+- Type: ERROR
+- Source: <HookName>
+- Area: <Area>
+- Priority: <low|medium|high>
+- Status: <pending|reviewed|promoted>
+- Logged: <ISO-8601 timestamp>
+
+### Summary
+<Short summary>
+
+### Details
+<Detailed context>
+
+---
+

--- a/.learnings/FEATURE_REQUESTS.md
+++ b/.learnings/FEATURE_REQUESTS.md
@@ -1,0 +1,24 @@
+# Feature Requests Log
+
+Structured logs for missing capability requests.
+
+## Entry Format
+
+Use this exact format for each entry:
+
+## FEAT-YYYYMMDD-XXX - <Title>
+- Type: FEATURE
+- Source: <HookName>
+- Area: <Area>
+- Priority: <low|medium|high>
+- Status: <pending|reviewed|promoted>
+- Logged: <ISO-8601 timestamp>
+
+### Summary
+<Short summary>
+
+### Details
+<Detailed context>
+
+---
+

--- a/.learnings/LEARNINGS.md
+++ b/.learnings/LEARNINGS.md
@@ -1,0 +1,24 @@
+# Learnings Log
+
+Structured logs for user-correction learnings.
+
+## Entry Format
+
+Use this exact format for each entry:
+
+## LRN-YYYYMMDD-XXX - <Title>
+- Type: LEARNING
+- Source: <HookName>
+- Area: <Area>
+- Priority: <low|medium|high>
+- Status: <pending|reviewed|promoted>
+- Logged: <ISO-8601 timestamp>
+
+### Summary
+<Short summary>
+
+### Details
+<Detailed context>
+
+---
+

--- a/.learnings/PROJECT_MEMORY.md
+++ b/.learnings/PROJECT_MEMORY.md
@@ -1,0 +1,4 @@
+# Project Memory
+
+Promoted learnings that became permanent project memory.
+

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -11,6 +11,7 @@ from app.core.database import get_history, get_user_state, save_message, save_us
 from app.core.prompts import get_system_prompt
 from app.core.dependencies import get_garmin, get_strava, get_code_executor
 from app.core.config import get_credential
+from app.self_improving.hooks import handle_user_prompt_submit
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +173,9 @@ async def chat(request: ChatRequest):
         user_msg = messages[-1].content
     else:
         user_msg = "..."
+
+    # Trigger UserPromptSubmit hook to auto-log learnings and feature requests.
+    handle_user_prompt_submit(user_msg, project_root=".")
 
     user_state = get_user_state(session_id)
     extracted_now = extract_user_state(user_msg)

--- a/app/self_improving/__init__.py
+++ b/app/self_improving/__init__.py
@@ -1,0 +1,5 @@
+"""Self-improving agent utilities for structured learning, error, and feature logging."""
+
+from .memory_logger import SelfImprovingMemoryLogger
+
+__all__ = ["SelfImprovingMemoryLogger"]

--- a/app/self_improving/hooks.py
+++ b/app/self_improving/hooks.py
@@ -1,0 +1,179 @@
+"""Hook handlers for UserPromptSubmit and PostToolUse self-improvement automation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from app.self_improving.memory_logger import MemoryEntry, SelfImprovingMemoryLogger
+
+
+def _contains_any(text: str, markers: list[str]) -> bool:
+    """Return True when at least one marker phrase appears in the lowercase text."""
+    lowered = text.lower()
+    return any(marker in lowered for marker in markers)
+
+
+def handle_user_prompt_submit(user_prompt: str, project_root: str = ".") -> list[str]:
+    """Inspect user prompts for learning/feature signals and log matching entries."""
+    logger = SelfImprovingMemoryLogger(project_root=project_root)
+    created_ids: list[str] = []
+
+    learning_markers = [
+        "you are wrong",
+        "that is wrong",
+        "incorrect",
+        "du har fel",
+        "det är fel",
+        "wrong answer",
+        "not correct",
+    ]
+    feature_markers = [
+        "feature request",
+        "missing feature",
+        "should support",
+        "please add",
+        "saknar",
+        "lägg till",
+    ]
+
+    if _contains_any(user_prompt, learning_markers):
+        created_ids.append(
+            logger.log_entry(
+                MemoryEntry(
+                    entry_type="learning",
+                    title="User reported incorrect assistant behavior",
+                    summary="The user indicated the assistant response was incorrect.",
+                    details=f"Original prompt/feedback: {user_prompt}",
+                    source="UserPromptSubmit",
+                    area="assistant-quality",
+                    priority="high",
+                )
+            )
+        )
+
+    if _contains_any(user_prompt, feature_markers):
+        created_ids.append(
+            logger.log_entry(
+                MemoryEntry(
+                    entry_type="feature",
+                    title="User requested missing capability",
+                    summary="The user asked for a capability not currently available.",
+                    details=f"Feature request context: {user_prompt}",
+                    source="UserPromptSubmit",
+                    area="product-gap",
+                    priority="medium",
+                )
+            )
+        )
+
+    return created_ids
+
+
+
+
+def _safe_json_loads(raw: str) -> dict[str, Any]:
+    """Parse JSON payloads defensively and fall back to a raw envelope on invalid input."""
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    except json.JSONDecodeError:
+        cleaned = raw.strip()
+        if cleaned.startswith("'") and cleaned.endswith("'"):
+            cleaned = cleaned[1:-1]
+        try:
+            parsed = json.loads(cleaned)
+            if isinstance(parsed, dict):
+                return parsed
+            return {"value": parsed}
+        except json.JSONDecodeError:
+            return {"raw": raw}
+
+
+def handle_post_tool_use(
+    tool_name: str,
+    tool_args: dict[str, Any],
+    result: dict[str, Any],
+    project_root: str = ".",
+) -> str | None:
+    """Log ERROR entries when tool execution result indicates a failure state."""
+    logger = SelfImprovingMemoryLogger(project_root=project_root)
+    ok = bool(result.get("ok", False))
+    if ok:
+        return None
+
+    text_output = str(result.get("text") or result.get("error") or "Unknown tool failure")
+    return logger.log_entry(
+        MemoryEntry(
+            entry_type="error",
+            title=f"Tool execution failure: {tool_name}",
+            summary="A tool call finished in a failed state.",
+            details=(
+                f"Tool: {tool_name}\n"
+                f"Arguments: {json.dumps(tool_args, ensure_ascii=False)}\n"
+                f"Output/Error: {text_output}"
+            ),
+            source="PostToolUse",
+            area="tooling",
+            priority="high",
+        )
+    )
+
+
+def _main() -> int:
+    """CLI entrypoint for shell wrappers to activate hooks without duplicating logic."""
+    parser = argparse.ArgumentParser(description="Self-improving hook runner")
+    subparsers = parser.add_subparsers(dest="event", required=True)
+
+    user_parser = subparsers.add_parser("UserPromptSubmit")
+    user_parser.add_argument("--prompt", required=True)
+    user_parser.add_argument("--project-root", default=".")
+
+    tool_parser = subparsers.add_parser("PostToolUse")
+    tool_parser.add_argument("--tool-name", required=True)
+    tool_parser.add_argument("--tool-args", default="{}")
+    tool_parser.add_argument("--result", required=True)
+    tool_parser.add_argument("--project-root", default=".")
+
+    pending_parser = subparsers.add_parser("ListPending")
+    pending_parser.add_argument("--project-root", default=".")
+
+    promote_parser = subparsers.add_parser("PromoteLearning")
+    promote_parser.add_argument("--learning-id", required=True)
+    promote_parser.add_argument("--rationale", default="")
+    promote_parser.add_argument("--project-root", default=".")
+
+    args = parser.parse_args()
+
+    if args.event == "UserPromptSubmit":
+        created = handle_user_prompt_submit(args.prompt, project_root=args.project_root)
+        print(json.dumps({"created": created}, ensure_ascii=False))
+        return 0
+
+    if args.event == "PostToolUse":
+        tool_args = _safe_json_loads(args.tool_args)
+        result = _safe_json_loads(args.result)
+        created_id = handle_post_tool_use(args.tool_name, tool_args, result, project_root=args.project_root)
+        print(json.dumps({"created": created_id}, ensure_ascii=False))
+        return 0
+
+    if args.event == "ListPending":
+        logger = SelfImprovingMemoryLogger(project_root=args.project_root)
+        print(json.dumps(logger.list_pending(), ensure_ascii=False, indent=2))
+        return 0
+
+    if args.event == "PromoteLearning":
+        logger = SelfImprovingMemoryLogger(project_root=args.project_root)
+        promoted = logger.promote_learning(args.learning_id, rationale=args.rationale)
+        print(json.dumps({"promoted": promoted}, ensure_ascii=False))
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/app/self_improving/id_generator.py
+++ b/app/self_improving/id_generator.py
@@ -1,0 +1,49 @@
+"""ID generation helpers for self-improving memory entries."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from random import randint
+from threading import Lock
+
+
+class EntryIDGenerator:
+    """Generate robust IDs in TYPE-YYYYMMDD-XXX format with local process uniqueness guards."""
+
+    _lock = Lock()
+    _last_date = ""
+    _sequence = 0
+
+    PREFIX_MAP = {
+        "learning": "LRN",
+        "error": "ERR",
+        "feature": "FEAT",
+    }
+
+    @classmethod
+    def generate(cls, entry_type: str, randomize: bool = False) -> str:
+        """Return a new ID with either sequential or randomized 3-digit suffix."""
+        normalized = entry_type.strip().lower()
+        if normalized not in cls.PREFIX_MAP:
+            raise ValueError(f"Unsupported entry type: {entry_type}")
+
+        prefix = cls.PREFIX_MAP[normalized]
+        date_part = datetime.now(timezone.utc).strftime("%Y%m%d")
+
+        with cls._lock:
+            if randomize:
+                suffix = randint(0, 999)
+            else:
+                if cls._last_date != date_part:
+                    cls._last_date = date_part
+                    cls._sequence = 0
+                cls._sequence += 1
+                suffix = cls._sequence
+
+        return f"{prefix}-{date_part}-{suffix:03d}"
+
+
+
+def iso_logged_timestamp() -> str:
+    """Return an ISO-8601 timestamp in UTC for the Logged metadata field."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/app/self_improving/memory_logger.py
+++ b/app/self_improving/memory_logger.py
@@ -1,0 +1,183 @@
+"""Structured markdown logger used by self-improving hooks and helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from app.self_improving.id_generator import EntryIDGenerator, iso_logged_timestamp
+
+EntryType = Literal["learning", "error", "feature"]
+
+
+@dataclass
+class MemoryEntry:
+    """Represents one markdown entry with normalized metadata fields."""
+
+    entry_type: EntryType
+    title: str
+    summary: str
+    details: str
+    source: str
+    area: str = "general"
+    priority: str = "medium"
+    status: str = "pending"
+
+
+class SelfImprovingMemoryLogger:
+    """Writes and reads learning/error/feature entries under .learnings/."""
+
+    FILES = {
+        "learning": "LEARNINGS.md",
+        "error": "ERRORS.md",
+        "feature": "FEATURE_REQUESTS.md",
+    }
+
+    def __init__(self, project_root: str | Path = ".") -> None:
+        """Initialize output paths and ensure baseline markdown files exist."""
+        self.project_root = Path(project_root)
+        self.learnings_dir = self.project_root / ".learnings"
+        self.learnings_dir.mkdir(parents=True, exist_ok=True)
+        self._ensure_default_files()
+
+    def _ensure_default_files(self) -> None:
+        """Create markdown logs with stable headers if they are missing."""
+        default_headers = {
+            "LEARNINGS.md": "# Learnings Log\n\nStructured logs for user-correction learnings.\n\n",
+            "ERRORS.md": "# Errors Log\n\nStructured logs for tool and runtime failures.\n\n",
+            "FEATURE_REQUESTS.md": "# Feature Requests Log\n\nStructured logs for missing capability requests.\n\n",
+            "PROJECT_MEMORY.md": "# Project Memory\n\nPromoted learnings that became permanent project memory.\n\n",
+        }
+        for filename, content in default_headers.items():
+            target = self.learnings_dir / filename
+            if not target.exists():
+                target.write_text(content, encoding="utf-8")
+
+    def log_entry(self, entry: MemoryEntry) -> str:
+        """Append one entry to the proper markdown file and return created entry ID."""
+        entry_id = EntryIDGenerator.generate(entry.entry_type)
+        logged = iso_logged_timestamp()
+
+        markdown_block = self._format_entry(
+            entry_id=entry_id,
+            entry_type=entry.entry_type,
+            title=entry.title,
+            source=entry.source,
+            area=entry.area,
+            priority=entry.priority,
+            status=entry.status,
+            logged=logged,
+            summary=entry.summary,
+            details=entry.details,
+        )
+
+        filepath = self.learnings_dir / self.FILES[entry.entry_type]
+        with filepath.open("a", encoding="utf-8") as handle:
+            handle.write(markdown_block)
+
+        return entry_id
+
+    @staticmethod
+    def _format_entry(
+        *,
+        entry_id: str,
+        entry_type: str,
+        title: str,
+        source: str,
+        area: str,
+        priority: str,
+        status: str,
+        logged: str,
+        summary: str,
+        details: str,
+    ) -> str:
+        """Enforce exact markdown entry structure (heading, metadata, summary, details)."""
+        normalized_type = entry_type.upper()
+        return (
+            f"## {entry_id} - {title}\n"
+            f"- Type: {normalized_type}\n"
+            f"- Source: {source}\n"
+            f"- Area: {area}\n"
+            f"- Priority: {priority}\n"
+            f"- Status: {status}\n"
+            f"- Logged: {logged}\n\n"
+            "### Summary\n"
+            f"{summary.strip()}\n\n"
+            "### Details\n"
+            f"{details.strip()}\n\n"
+            "---\n\n"
+        )
+
+    def promote_learning(self, learning_id: str, rationale: str = "") -> bool:
+        """Promote a LEARNING entry into permanent memory and mark it promoted in source log."""
+        learnings_path = self.learnings_dir / "LEARNINGS.md"
+        content = learnings_path.read_text(encoding="utf-8")
+
+        marker = f"## {learning_id} - "
+        if marker not in content:
+            return False
+
+        chunks = content.split("## ")
+        selected = ""
+        rebuilt_chunks = [chunks[0]]
+
+        for raw_chunk in chunks[1:]:
+            chunk = "## " + raw_chunk
+            if chunk.startswith(marker):
+                selected = chunk
+                if "- Status: pending" in chunk:
+                    chunk = chunk.replace("- Status: pending", "- Status: promoted", 1)
+                elif "- Status: reviewed" in chunk:
+                    chunk = chunk.replace("- Status: reviewed", "- Status: promoted", 1)
+            rebuilt_chunks.append(chunk)
+
+        learnings_path.write_text("".join(rebuilt_chunks), encoding="utf-8")
+
+        if not selected:
+            return False
+
+        project_memory_path = self.learnings_dir / "PROJECT_MEMORY.md"
+        promoted_block = (
+            f"## Promoted {learning_id}\n"
+            f"- PromotedAt: {iso_logged_timestamp()}\n"
+            f"- Rationale: {rationale or 'No rationale provided.'}\n\n"
+            f"{selected.strip()}\n\n"
+            "---\n\n"
+        )
+        with project_memory_path.open("a", encoding="utf-8") as handle:
+            handle.write(promoted_block)
+
+        return True
+
+    def list_pending(self) -> dict[str, dict[str, list[str]]]:
+        """Return pending entries grouped by area and then priority across all logs."""
+        grouped: dict[str, dict[str, list[str]]] = {}
+
+        for file_name in self.FILES.values():
+            file_path = self.learnings_dir / file_name
+            if not file_path.exists():
+                continue
+
+            content = file_path.read_text(encoding="utf-8")
+            entries = [f"## {chunk.strip()}" for chunk in content.split("## ") if chunk.strip()]
+            for entry in entries:
+                if "- Status: pending" not in entry:
+                    continue
+
+                heading = entry.splitlines()[0].strip().replace("## ", "")
+                area = self._extract_metadata(entry, "Area") or "general"
+                priority = self._extract_metadata(entry, "Priority") or "medium"
+
+                grouped.setdefault(area, {}).setdefault(priority, []).append(heading)
+
+        return grouped
+
+    @staticmethod
+    def _extract_metadata(entry_markdown: str, key: str) -> str:
+        """Extract metadata values from one entry using simple line matching."""
+        prefix = f"- {key}: "
+        for line in entry_markdown.splitlines():
+            if line.startswith(prefix):
+                return line.replace(prefix, "", 1).strip()
+        return ""

--- a/app/self_improving/pending_helper.py
+++ b/app/self_improving/pending_helper.py
@@ -1,0 +1,19 @@
+"""Helper for listing pending self-improving entries by area and priority."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.self_improving.memory_logger import SelfImprovingMemoryLogger
+
+
+def print_pending_entries(project_root: str | Path = ".") -> None:
+    """Print pending entries grouped by area and priority as formatted JSON."""
+    logger = SelfImprovingMemoryLogger(project_root=project_root)
+    grouped = logger.list_pending()
+    print(json.dumps(grouped, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    print_pending_entries()

--- a/app/services/tool_call_router.py
+++ b/app/services/tool_call_router.py
@@ -9,6 +9,7 @@ import httpx
 
 from app.core.config import settings
 from app.core.logging import logger
+from app.self_improving.hooks import handle_post_tool_use
 
 
 class ToolCallRouter:
@@ -89,8 +90,12 @@ class ToolCallRouter:
                 if attempt <= self.retries:
                     await asyncio.sleep(min(1.5 * attempt, 4.0))
 
-        return {
+        failed_result = {
             "ok": False,
             "tool": tool_name,
             "text": f"Gateway call failed for {tool_name}: {last_error}",
         }
+
+        # Trigger PostToolUse hook for automatic structured error logging.
+        handle_post_tool_use(tool_name, tool_args, failed_result, project_root=".")
+        return failed_result

--- a/scripts/activator.sh
+++ b/scripts/activator.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Activates self-improving hook flows for user prompts and pending summaries.
+set -euo pipefail
+
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+EVENT="${1:-UserPromptSubmit}"
+
+case "$EVENT" in
+  UserPromptSubmit)
+    PROMPT="${2:-}"
+    python -m app.self_improving.hooks UserPromptSubmit --project-root "$PROJECT_ROOT" --prompt "$PROMPT"
+    ;;
+  ListPending)
+    python -m app.self_improving.hooks ListPending --project-root "$PROJECT_ROOT"
+    ;;
+  PromoteLearning)
+    LEARNING_ID="${2:-}"
+    RATIONALE="${3:-}"
+    python -m app.self_improving.hooks PromoteLearning --project-root "$PROJECT_ROOT" --learning-id "$LEARNING_ID" --rationale "$RATIONALE"
+    ;;
+  *)
+    echo "Unsupported event: $EVENT" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/error-detector.sh
+++ b/scripts/error-detector.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Detects failed tool runs and logs ERROR entries through the PostToolUse hook.
+set -euo pipefail
+
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+TOOL_NAME="${1:-unknown_tool}"
+TOOL_ARGS_JSON="${2:-{}}"
+RESULT_JSON="${3:-{\"ok\":false,\"text\":\"unknown failure\"}}"
+
+python -m app.self_improving.hooks PostToolUse \
+  --project-root "$PROJECT_ROOT" \
+  --tool-name "$TOOL_NAME" \
+  --tool-args "$TOOL_ARGS_JSON" \
+  --result "$RESULT_JSON"

--- a/scripts/extract-skill.sh
+++ b/scripts/extract-skill.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Extracts high-value learning summaries that can be converted into durable skills.
+set -euo pipefail
+
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+LEARNINGS_FILE="$PROJECT_ROOT/.learnings/LEARNINGS.md"
+
+if [[ ! -f "$LEARNINGS_FILE" ]]; then
+  echo "No learnings file found at $LEARNINGS_FILE" >&2
+  exit 1
+fi
+
+awk '
+  /^## / {heading=$0}
+  /^### Summary/ {getline; summary=$0; if (summary != "") {print heading "\n- SkillCandidate: " summary "\n"}}
+' "$LEARNINGS_FILE"

--- a/tests/test_self_improving_agent.py
+++ b/tests/test_self_improving_agent.py
@@ -1,0 +1,93 @@
+"""Verification tests for markdown format, ID generation, and pending helper behavior."""
+
+from __future__ import annotations
+
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.self_improving.id_generator import EntryIDGenerator
+from app.self_improving.memory_logger import MemoryEntry, SelfImprovingMemoryLogger
+
+
+class SelfImprovingAgentTests(unittest.TestCase):
+    """Validate required formatting and behavior for self-improving logs."""
+
+    def setUp(self) -> None:
+        """Create an isolated temporary project root for each test case."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.logger = SelfImprovingMemoryLogger(project_root=self.root)
+
+    def tearDown(self) -> None:
+        """Clean up the temporary directory after each test run."""
+        self.temp_dir.cleanup()
+
+    def test_id_format_for_all_types(self) -> None:
+        """Ensure generated IDs follow TYPE-YYYYMMDD-XXX exactly."""
+        patterns = {
+            "learning": r"^LRN-\d{8}-\d{3}$",
+            "error": r"^ERR-\d{8}-\d{3}$",
+            "feature": r"^FEAT-\d{8}-\d{3}$",
+        }
+
+        for entry_type, pattern in patterns.items():
+            generated = EntryIDGenerator.generate(entry_type)
+            self.assertRegex(generated, pattern)
+
+    def test_markdown_entry_format_is_strict(self) -> None:
+        """Ensure each stored entry contains heading, metadata, summary, and details sections."""
+        self.logger.log_entry(
+            MemoryEntry(
+                entry_type="learning",
+                title="Test learning",
+                summary="A concise summary.",
+                details="Detailed context for validation.",
+                source="UserPromptSubmit",
+                area="testing",
+                priority="high",
+            )
+        )
+
+        content = (self.root / ".learnings" / "LEARNINGS.md").read_text(encoding="utf-8")
+
+        strict_pattern = re.compile(
+            r"## LRN-\d{8}-\d{3} - Test learning\n"
+            r"- Type: LEARNING\n"
+            r"- Source: UserPromptSubmit\n"
+            r"- Area: testing\n"
+            r"- Priority: high\n"
+            r"- Status: pending\n"
+            r"- Logged: \d{4}-\d{2}-\d{2}T.*Z\n\n"
+            r"### Summary\n"
+            r"A concise summary\.\n\n"
+            r"### Details\n"
+            r"Detailed context for validation\.\n\n"
+            r"---",
+            re.MULTILINE,
+        )
+        self.assertRegex(content, strict_pattern)
+
+    def test_pending_grouping_by_area_and_priority(self) -> None:
+        """Ensure helper grouping returns pending entries in nested area/priority buckets."""
+        self.logger.log_entry(
+            MemoryEntry(
+                entry_type="feature",
+                title="Missing webhook retry setting",
+                summary="Need retry controls.",
+                details="Users request custom retry strategy.",
+                source="UserPromptSubmit",
+                area="integrations",
+                priority="medium",
+            )
+        )
+
+        grouped = self.logger.list_pending()
+        self.assertIn("integrations", grouped)
+        self.assertIn("medium", grouped["integrations"])
+        self.assertTrue(any("Missing webhook retry setting" in item for item in grouped["integrations"]["medium"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Implement a self-improving subsystem to automatically capture learnings, tool errors and feature requests in structured markdown for later review and promotion to project memory.
- Provide hooks that trigger on user feedback (`UserPromptSubmit`) and tool failures (`PostToolUse`) so logging happens automatically in runtime flows.
- Add simple CLI/shell tooling and helpers to list pending items and extract candidate skills from learnings.
- Ensure entries follow a strict machine-parseable markdown format and have robust IDs and timestamps for traceability.

### Description
- Added a new package `app/self_improving/` with: `id_generator.py` (TYPE-YYYYMMDD-XXX IDs + ISO-8601 logged timestamps), `memory_logger.py` (structured markdown writer, promotion to `PROJECT_MEMORY.md`, pending-grouping), `hooks.py` (handlers + CLI entrypoints), `pending_helper.py` and `__init__.py`.
- Integrated hooks into runtime: `handle_user_prompt_submit` is invoked from the chat endpoint (`app/routers/chat.py`) and `handle_post_tool_use` is invoked when tool gateway calls fail in `app/services/tool_call_router.py`.
- Created baseline markdown logs under `.learnings/`: `LEARNINGS.md`, `ERRORS.md`, `FEATURE_REQUESTS.md`, and `PROJECT_MEMORY.md` with the exact entry format required (heading, metadata, Summary, Details).
- Added shell utilities: `scripts/activator.sh`, `scripts/error-detector.sh`, `scripts/extract-skill.sh` for invoking hooks and extracting skill candidates.
- Added automated verification tests in `tests/test_self_improving_agent.py` covering ID format, strict markdown entry format, and pending-grouping behavior.

### Testing
- Ran the unit test suite with `python -m unittest tests/test_self_improving_agent.py`, which executed 3 tests and all passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d933a66f88333b27e67898d3be47f)