### PR TITLE
chore: cleanup imports, fix mutable defaults, centralize CORS and add regression tests

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     HOST: str = "0.0.0.0"
     PORT: int = 8000
+    ALLOWED_ORIGINS: str = "http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000"
     
     # API Keys
     GOOGLE_API_KEY: Optional[str] = None
@@ -88,3 +89,12 @@ def get_credential(key: str, fallback=None) -> str:
 import os
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 DB_PATH = os.path.join(BASE_DIR, "db", "mainframe.db")
+
+
+
+def get_allowed_origins() -> list[str]:
+    """Return normalized CORS origins from settings."""
+    raw = (settings.ALLOWED_ORIGINS or "").strip()
+    if not raw:
+        return []
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]

--- a/app/services/llm_handler.py
+++ b/app/services/llm_handler.py
@@ -91,23 +91,35 @@ async def tool_get_calendar(start: str, end: str):
 
 async def tool_control_light(entity_id: str, action: str):
     """Controls lights (on/off)."""
-    try: return await control_light(entity_id, action)
-    except: return "Could not control light."
+    try:
+        return await control_light(entity_id, action)
+    except Exception:
+        logger.exception("[TOOL] Could not control light")
+        return "Could not control light."
 
 async def tool_control_vacuum(entity_id: str, action: str):
     """Controls vacuum (start/stop/dock)."""
-    try: return await control_vacuum(entity_id, action)
-    except: return "Could not control vacuum."
+    try:
+        return await control_vacuum(entity_id, action)
+    except Exception:
+        logger.exception("[TOOL] Could not control vacuum")
+        return "Could not control vacuum."
 
 async def tool_get_ha_state(entity_id: str):
     """Fetches status for a device."""
-    try: return await get_ha_state(entity_id)
-    except: return "Could not fetch status."
+    try:
+        return await get_ha_state(entity_id)
+    except Exception:
+        logger.exception("[TOOL] Could not fetch HA state")
+        return "Could not fetch status."
 
 async def tool_get_sensor(friendly_name: str):
     """Fetches sensor data."""
-    try: return await get_sensor_data(friendly_name)
-    except: return "Could not fetch sensor data."
+    try:
+        return await get_sensor_data(friendly_name)
+    except Exception:
+        logger.exception("[TOOL] Could not fetch sensor data")
+        return "Could not fetch sensor data."
 
 def tool_analyze_health_data():
     """Helper function to analyze health data."""
@@ -128,6 +140,8 @@ daa_tools = [
 
 # --- MAIN STREAMING FUNCTION ---
 async def stream_response(model_id, history, new_message, image_data=None, system_injection=None):
+    base_system_prompt = get_system_prompt()
+
     # --- MEM0 ---
     mem0_key = settings.MEM0_API_KEY
     mem0_client = None

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -2,7 +2,6 @@ from google import genai
 from google.genai import types
 from app.core.config import settings
 from app.core.logging import logger
-from app.services.tool_registry import registry
 import base64
 
 class LLMService:
@@ -14,7 +13,7 @@ class LLMService:
         else:
             logger.warning("GOOGLE_API_KEY not found. LLM capabilities limited.")
 
-    async def generate_response(self, prompt: str, image_data: str = None, history: list = []):
+    async def generate_response(self, prompt: str, image_data: str = None, history: list | None = None):
         """
         Generates a streaming response from Gemini.
         """
@@ -24,6 +23,7 @@ class LLMService:
 
         model_id = "gemini-2.0-flash" 
         
+        history = history or []
         contents = []
         # Add history
         # TODO: Format history correctly for Gemini 2.0

--- a/docs/code-analysis-2026-02-11.md
+++ b/docs/code-analysis-2026-02-11.md
@@ -1,0 +1,82 @@
+# Code Analysis of Freja.io
+
+Date: 2026-02-11
+
+## Overview
+The project has a solid base structure (FastAPI + Socket.IO backend and React client), but there are several risk areas affecting reliability, security, and maintainability.
+
+## Prioritized Improvements
+
+### P0 — Critical Issues (address immediately)
+
+1. **`base_system_prompt` was used before initialization** in `stream_response`, which risked runtime errors.
+   - File: `app/services/llm_handler.py`.
+   - Recommendation: initialize prompt at function start via `get_system_prompt()` and use a local immutable flow.
+
+2. **Overly permissive CORS settings in production defaults** (`"*"` previously allowed with credentials).
+   - File: `main.py` + `app/core/config.py`.
+   - Recommendation: drive allowed origins from config (`ALLOWED_ORIGINS`) and avoid wildcards in production.
+
+3. **Safety filters configured with permissive thresholds** (`BLOCK_NONE`) in model flows.
+   - Files: `app/services/llm_handler.py`, `app/routers/chat.py`.
+   - Recommendation: set stricter production thresholds and gate relaxed behavior behind env flags.
+
+### P1 — High Priority (stability and observability)
+
+4. **Broad exception handling (`except:` / generic swallowing)** hides root causes.
+   - Files: multiple modules including service and router layers.
+   - Recommendation: catch explicit exception types where possible and log contextual diagnostics.
+
+5. **Mutable default argument (`history=[]`)** in LLM service API.
+   - File: `app/services/llm_service.py`.
+   - Recommendation: use `history: list | None = None` and initialize locally.
+
+6. **Global Socket.IO session state without a dedicated manager** can create race/lifecycle edge cases.
+   - File: `main.py`.
+   - Recommendation: move to a session manager abstraction with cleanup/TTL/reconnect handling.
+
+### P2 — Medium Priority (architecture and quality)
+
+7. **`main.py` is too monolithic** (startup, middleware, routes, static serving, socket handlers in one file).
+   - Recommendation: split into `app_factory`, `socket_handlers`, and static route modules.
+
+8. **Hardcoded project sync path in Docker executor** (`/opt/mainframe`) reduces portability.
+   - File: `app/tools/code_executor.py`.
+   - Recommendation: resolve from runtime base path/config.
+
+9. **Known technical debt markers (`TODO`) in core flows** (tool schema introspection, voice handshake, proactive logic).
+   - Recommendation: create a tracked implementation roadmap with owners and acceptance criteria.
+
+## Suggested 4-Sprint Plan
+
+### Sprint 1 — Stability/Security
+- Ensure prompt initialization across all LLM entry points.
+- Harden CORS and environment-specific defaults.
+- Replace fragile exception handling in critical paths.
+- Add centralized error handling + correlation IDs in logs.
+
+### Sprint 2 — Architecture
+- Break down `main.py` into focused modules.
+- Introduce a `SessionManager` for chat/voice lifecycle.
+- Define and validate tool contracts (Pydantic schemas).
+
+### Sprint 3 — Test Coverage
+- Add unit tests for:
+  - prompt composition
+  - tool payload parsing
+  - socket session lifecycle
+- Add integration tests for `/health`, chat route, and socket handshake.
+
+### Sprint 4 — Operations/Observability
+- Add metrics (latency per model/tool, failure rate, cost visibility).
+- Introduce structured logs and dashboards.
+- Add rate limiting and stricter input validation for external calls.
+
+## Quick Wins
+- Keep prompt initialization explicit at entry points.
+- Keep mutable defaults out of public APIs.
+- Keep CORS origin list explicit and environment-driven.
+- Replace top bare exception handlers with actionable logging.
+
+## Summary
+The codebase is promising and functional, but a few concentrated fixes deliver high value quickly: robust prompt handling, safer defaults, stronger error observability, and cleaner application modularization.

--- a/main.py
+++ b/main.py
@@ -1,11 +1,10 @@
 import socketio
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.core.config import settings
+from app.core.config import settings, get_allowed_origins
 from app.core.logging import logger
 from app.services.voice_service import init_voice_service
 from app.services.proactive_service import init_proactive_service
-from app.services.tool_registry import registry
 from contextlib import asynccontextmanager
 
 # Import tools to register them
@@ -35,20 +34,14 @@ app = FastAPI(title=settings.APP_NAME, lifespan=lifespan)
 # CORS Middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",
-        "http://127.0.0.1:5173",
-        "http://localhost:3000",
-        "http://192.168.107.17:3000",
-        "*"
-    ],
+    allow_origins=get_allowed_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
 # Socket.IO Setup
-sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
+sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins=get_allowed_origins())
 app_socketio = socketio.ASGIApp(sio, app)
 
 # Routes

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.core.config import get_allowed_origins, settings
+
+
+def test_get_allowed_origins_parses_and_trims(monkeypatch):
+    monkeypatch.setattr(settings, "ALLOWED_ORIGINS", " http://a.com,https://b.com , ,http://c.local ")
+
+    assert get_allowed_origins() == [
+        "http://a.com",
+        "https://b.com",
+        "http://c.local",
+    ]
+
+
+def test_get_allowed_origins_handles_empty(monkeypatch):
+    monkeypatch.setattr(settings, "ALLOWED_ORIGINS", "")
+
+    assert get_allowed_origins() == []

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,43 @@
+import ast
+from pathlib import Path
+
+
+def _parse(path: str) -> ast.AST:
+    return ast.parse(Path(path).read_text())
+
+
+def test_llm_service_generate_response_has_no_mutable_default():
+    tree = _parse("app/services/llm_service.py")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "generate_response":
+            defaults = node.args.defaults
+            assert defaults, "Expected defaults for optional parameters"
+            assert not any(isinstance(default, ast.List) for default in defaults)
+            return
+
+    raise AssertionError("generate_response function was not found")
+
+
+def test_socketio_server_uses_configured_allowed_origins():
+    tree = _parse("main.py")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            if not any(isinstance(t, ast.Name) and t.id == "sio" for t in node.targets):
+                continue
+            if not isinstance(node.value, ast.Call):
+                continue
+
+            call = node.value
+            if not (isinstance(call.func, ast.Attribute) and call.func.attr == "AsyncServer"):
+                continue
+
+            cors_kw = next((kw for kw in call.keywords if kw.arg == "cors_allowed_origins"), None)
+            assert cors_kw is not None, "Expected cors_allowed_origins keyword"
+            assert isinstance(cors_kw.value, ast.Call), "Expected get_allowed_origins() call"
+            assert isinstance(cors_kw.value.func, ast.Name), "Expected direct function call"
+            assert cors_kw.value.func.id == "get_allowed_origins"
+            return
+
+    raise AssertionError("sio AsyncServer assignment was not found")


### PR DESCRIPTION
### Motivation
- Prevent runtime and maintenance issues by initializing prompt state before use and avoiding mutable default arguments in public APIs.
- Centralize CORS configuration to make origin handling environment-driven and consistent between FastAPI and Socket.IO.
- Improve observability by replacing silent `except:` blocks with logged exceptions to aid debugging.
- Add durable AST-based regression tests to prevent these regressions from reappearing.

### Description
- Added `ALLOWED_ORIGINS` to `app/core/config.py` and implemented `get_allowed_origins()` to parse and normalize origin lists from settings.
- Updated `main.py` to use `get_allowed_origins()` for FastAPI `CORSMiddleware` and for `socketio.AsyncServer` `cors_allowed_origins`, and removed an unused `registry` import.
- Fixed `app/services/llm_service.py` to remove an unused `registry` import and replaced the mutable default `history: list = []` with `history: list | None = None` and local initialization `history = history or []`.
- Initialized `base_system_prompt` at the start of `stream_response` in `app/services/llm_handler.py` and replaced several bare `except:` handlers with logged exceptions via `logger.exception(...)` in tool wrappers.
- Added tests: `tests/test_config.py` (unit tests for `get_allowed_origins`) and `tests/test_regressions.py` (AST checks ensuring no mutable defaults in `generate_response` and that `socketio.AsyncServer` uses `get_allowed_origins()`).
- Added a `docs/code-analysis-2026-02-11.md` file summarizing the analysis and recommended fixes.

### Testing
- Ran the test suite with `pytest -q` and all tests passed: `4 passed`.
- The new AST-based regression tests `tests/test_regressions.py` and the config tests in `tests/test_config.py` were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c91ea42ac833393610a4b97f3951c)