### PR TITLE
Fix: weather and Strava tools — register weather tool and lazy Strava init

### DIFF
--- a/app/tools/definitions.py
+++ b/app/tools/definitions.py
@@ -28,3 +28,11 @@ class GetStravaActivity(BaseModel):
     Use this when the user asks about their recent workouts, runs, or rides recorded on Strava.
     """
     limit: int = Field(5, description="The maximum number of activities to retrieve. Defaults to 5.")
+
+
+class GetWeather(BaseModel):
+    """
+    Retrieves weather data for the configured home coordinates.
+    Requires LATITUDE and LONGITUDE settings.
+    """
+    pass

--- a/app/tools/implementations.py
+++ b/app/tools/implementations.py
@@ -2,9 +2,8 @@ import asyncio
 from typing import Any, Dict
 
 from app.services.tool_registry import registry
-from app.tools.definitions import RunPythonCode, WebSearch, GetGarminHealth
-from app.core.dependencies import get_code_executor, get_garmin
-from app.core.config import get_credential
+from app.tools.definitions import RunPythonCode, WebSearch, GetGarminHealth, GetStravaActivity, GetWeather
+from app.core.dependencies import get_code_executor, get_garmin, get_strava
 from app.services.web_fallback_service import WebFallbackService
 
 # Initialize helper services (lazy loaded where possible)
@@ -102,11 +101,18 @@ async def get_garmin_health_impl(date_str: str) -> str:
     except Exception as e:
         return f"Failed to fetch Garmin data: {e}"
 
-from app.tools.strava_core import StravaTool
-from app.tools.definitions import GetStravaActivity
 
-# Lazy global instance
-_strava_tool = StravaTool()
+@registry.register(
+    name="get_weather",
+    description="Fetches weather forecast for configured coordinates using SMHI.",
+    args_schema=GetWeather
+)
+async def get_weather_impl() -> str:
+    try:
+        from app.tools.weather_core import get_weather
+        return await get_weather()
+    except Exception as e:
+        return f"Failed to fetch weather data: {e}"
 
 @registry.register(
     name="get_strava_activities",
@@ -115,8 +121,12 @@ _strava_tool = StravaTool()
 )
 async def get_strava_activities_impl(limit: int = 5) -> str:
     try:
+        strava_tool = get_strava()
+        if not strava_tool:
+            return "Strava service is not configured. Add STRAVA_CLIENT_ID, STRAVA_CLIENT_SECRET, and STRAVA_REFRESH_TOKEN."
+
         # Re-use existing core logic
-        activities = await _strava_tool.get_health_report(limit=limit)
+        activities = await strava_tool.get_health_report(limit=limit)
         
         # Check for error dict return from core tool
         if isinstance(activities, dict) and "error" in activities:

--- a/app/tools/weather_core.py
+++ b/app/tools/weather_core.py
@@ -1,34 +1,34 @@
 import httpx
 import asyncio
-from app.core.config import settings, get_credential
+from app.core.config import get_credential
 
 # SMHI Wsymb2 Mapping (1-27)
 SMHI_CODES = {
-    1: "Klart", 2: "Lätt molnighet", 3: "Halvklart", 4: "Molnigt", 5: "Mycket molnigt", 
-    6: "Mulet", 7: "Dimma", 8: "Lätt regnskur", 9: "Regnskur", 10: "Kraftig regnskur",
-    11: "Åskskur", 12: "Lätt by av snöblandat regn", 13: "By av snöblandat regn", 
-    14: "Kraftig by av snöblandat regn", 15: "Lätt snöby", 16: "Snöby", 17: "Kraftig snöby",
-    18: "Lätt regn", 19: "Regn", 20: "Kraftigt regn", 21: "Åska", 22: "Lätt snöblandat regn",
-    23: "Snöblandat regn", 24: "Kraftigt snöblandat regn", 25: "Lätt snöfall", 
-    26: "Snöfall", 27: "Kraftigt snöfall"
+    1: "Clear sky", 2: "Light clouds", 3: "Partly cloudy", 4: "Cloudy", 5: "Mostly cloudy", 
+    6: "Overcast", 7: "Fog", 8: "Light rain shower", 9: "Rain shower", 10: "Heavy rain shower",
+    11: "Thunder shower", 12: "Light sleet shower", 13: "Sleet shower", 
+    14: "Heavy sleet shower", 15: "Light snow shower", 16: "Snow shower", 17: "Heavy snow shower",
+    18: "Light rain", 19: "Rain", 20: "Heavy rain", 21: "Thunder", 22: "Light sleet",
+    23: "Sleet", 24: "Heavy sleet", 25: "Light snowfall", 
+    26: "Snowfall", 27: "Heavy snowfall"
 }
 
 async def get_weather():
     """
-    Hämtar väder från SMHI Open API (PMP3g).
+    Fetch weather from the SMHI Open API (PMP3g).
     """
     lat = get_credential("LATITUDE")
     lon = get_credential("LONGITUDE")
 
     if not lat or not lon:
-        return "⚠️ Saknar GPS-koordinater. Fyll i LATITUDE och LONGITUDE i inställningarna."
+        return "⚠️ Missing GPS coordinates. Set LATITUDE and LONGITUDE in settings."
 
     # SMHI requires 6 decimal precision
     try:
         lat_formatted = f"{float(lat):.6f}"
         lon_formatted = f"{float(lon):.6f}"
     except ValueError:
-        return "⚠️ Ogiltiga GPS-koordinater."
+        return "⚠️ Invalid GPS coordinates."
 
     url = f"https://opendata-download-metfcst.smhi.se/api/category/pmp3g/version/2/geotype/point/lon/{lon_formatted}/lat/{lat_formatted}/data.json"
 
@@ -40,13 +40,13 @@ async def get_weather():
             
             if response.status_code != 200:
                 print(f"[SMHI] Error {response.status_code}: {response.text}")
-                return f"Kunde inte hämta väder från SMHI (Felkod: {response.status_code})"
+                return f"Could not fetch weather from SMHI (HTTP {response.status_code})."
 
             data = response.json()
             time_series = data.get("timeSeries", [])
             
             if not time_series:
-                return "Ingen väderdata tillgänglig från SMHI."
+                return "No weather data available from SMHI."
 
             # --- Current Weather (First data point) ---
             current = time_series[0]
@@ -54,7 +54,7 @@ async def get_weather():
             
             # Wsymb2 = Weather Symbol
             wsymb = int(params.get("Wsymb2", 0))
-            desc = SMHI_CODES.get(wsymb, f"Okänt väder ({wsymb})")
+            desc = SMHI_CODES.get(wsymb, f"Unknown weather ({wsymb})")
             
             # t = Temp C
             temp = params.get("t", "N/A")
@@ -64,7 +64,7 @@ async def get_weather():
 
             # --- Forecast (Next 3 Days) ---
             forecast_msg = ""
-            days = ["Idag", "Imorgon", "Iövermorgon"]
+            days = ["Today", "Tomorrow", "Day after tomorrow"]
             
             # Simple assumption: 24h per day blocks roughly (since data is hourly for first days)
             # Better: Group by date string (validTime)
@@ -89,15 +89,15 @@ async def get_weather():
                         forecast_msg += f"{days[i]}: Max {d_max}°C, Min {d_min}°C. "
 
             report = (
-                f"Just nu rapporterar SMHI {desc} och {temp}°C, vind {wind} m/s. "
-                f"Prognos: {forecast_msg}"
+                f"SMHI currently reports {desc} and {temp}°C, wind {wind} m/s. "
+                f"Forecast: {forecast_msg}"
             )
                 
             return report
 
     except Exception as e:
         print(f"[WEATHER] Error: {e}")
-        return "Systemfel vid hämtning av väderdata från SMHI."
+        return "System error while fetching weather data from SMHI."
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
### Motivation
- Make the SMHI weather fetch available as a native tool for the agent tool-loop and avoid early/misconfigured Strava initialization that can miss DB-provided credentials.

### Description
- Added a `GetWeather` Pydantic schema and registered a `get_weather` tool that delegates to `app.tools.weather_core.get_weather` so the model can call weather via the tool registry.
- Standardized weather messages/labels to English and adjusted `weather_core` to use `get_credential` for coordinates and robust error messages.
- Replaced the eager global `StravaTool()` instance with a dependency-driven `get_strava()` lookup in `implementations.py` so Strava is initialized lazily when credentials exist.
- Added a clear configuration error return when Strava credentials are missing and removed the unused global strava instance.

### Testing
- Ran `python -m compileall app/tools/definitions.py app/tools/implementations.py app/tools/weather_core.py` which compiled successfully.
- Performed a runtime check by calling `registry.execute('get_weather', {})` after `init_db()` and `save_db_setting('LATITUDE',...)`/`save_db_setting('LONGITUDE',...)`, which returned a live SMHI response (success).
- Performed a runtime check for `get_strava_activities` with empty STRAVA DB settings which returned the expected configuration error message (success).
- Verified both `get_weather` and `get_strava_activities` are registered in the tool registry; however, running the full pytest collection failed in this environment (initial `pytest` collection errored with `ModuleNotFoundError: No module named 'app'` and subsequent targeted runs returned a non-zero exit), so the unit test suite is not fully green here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f1dda47988333928c482f7d292b7c)