### PR TITLE
Add Home Assistant skill with REST client, command parser, Telegram & chat routing, and tests

### DIFF
--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -14,6 +14,7 @@ from app.core.dependencies import get_code_executor, get_garmin, get_strava
 from app.core.prompts import get_system_prompt
 from app.self_improving.hooks import handle_user_prompt_submit
 from app.services.web_fallback_service import WebFallbackService, needs_web_fallback
+from skills.homeassistant import get_homeassistant_command_processor
 # --- Native Tooling Imports ---
 from app.services.tool_registry import registry
 # Ensure tools are registered
@@ -52,7 +53,16 @@ class UnifiedChatService:
 
         logger.info(f"Processing message for session {session_id} with model {model_id}")
 
-        # 2. Logic Hook (Self-improving)
+        # 2. Direct Home Assistant command route.
+        # This keeps deterministic HA command behavior for inputs like "ha list".
+        ha_processor = get_homeassistant_command_processor()
+        ha_result = await ha_processor.process_message(session_id, user_msg)
+        if ha_result.handled and ha_result.response:
+            save_message(session_id, "user", user_msg)
+            save_message(session_id, "assistant", ha_result.response)
+            return ha_result.response
+
+        # 3. Logic Hook (Self-improving)
         handle_user_prompt_submit(user_msg, project_root=".")
 
         # 3. User State & Profile Memory

--- a/app/services/telegram_service.py
+++ b/app/services/telegram_service.py
@@ -20,6 +20,7 @@ from app.core.database import get_db_settings
 from app.services.speech_to_text import build_speech_to_text_provider
 from app.services.telegram_voice_handler import TelegramVoiceError, TelegramVoiceHandler
 from skills.strava import get_strava_command_processor
+from skills.homeassistant import get_homeassistant_command_processor
 
 logger = logging.getLogger(__name__)
 
@@ -87,8 +88,9 @@ class TelegramService:
 
             # Add handlers.
             self.application.add_handler(CommandHandler("start", self._handle_start))
-            # Register dedicated Strava command route without affecting generic text handling.
+            # Register dedicated skill routes without affecting generic text handling.
             self.application.add_handler(CommandHandler("strava", self._handle_strava_command))
+            self.application.add_handler(CommandHandler("ha", self._handle_homeassistant_command))
             self.application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_text_message))
             self.application.add_handler(MessageHandler(filters.VOICE, self._handle_voice_message))
 
@@ -181,6 +183,23 @@ class TelegramService:
             return
 
         await update.message.reply_text("Svar:\nOkänt Strava-kommando.")
+
+
+    async def _handle_homeassistant_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle /ha command by routing to Home Assistant skill parser."""
+        if not update.message or not update.effective_chat:
+            return
+
+        chat_id = str(update.effective_chat.id)
+        message_text = (update.message.text or "").strip()
+        processor = get_homeassistant_command_processor()
+        result = await processor.process_message(chat_id, message_text)
+
+        if result.handled and result.response:
+            await update.message.reply_text(result.response)
+            return
+
+        await update.message.reply_text("Svar:\nOkänt HA-kommando.")
 
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle incoming Telegram text messages using the shared pipeline."""

--- a/skills/homeassistant/README.md
+++ b/skills/homeassistant/README.md
@@ -1,0 +1,32 @@
+# Home Assistant Skill
+
+This skill adds basic Home Assistant REST control in Freja.
+
+## Setup
+
+Set these environment variables:
+
+- `HA_URL` (example: `http://homeassistant.local:8123`)
+- `HA_TOKEN` (long-lived access token)
+
+`HA_URL` is normalized automatically, so trailing slash is optional.
+
+## Supported Commands
+
+- `ha list`
+- `ha list light`
+- `ha get light.kitchen`
+- `ha service switch turn_on {"entity_id":"switch.office_lamp"}`
+- `ha on switch.office_lamp`
+- `ha off switch.office_lamp`
+- `ha scene scene.movie_time`
+
+The same command set can be used in Telegram as `/ha ...`.
+
+## Optional curl examples
+
+```bash
+curl -H "Authorization: Bearer $HA_TOKEN" "$HA_URL/api/states"
+curl -X POST -H "Authorization: Bearer $HA_TOKEN" -H "Content-Type: application/json" \
+  -d '{"entity_id":"switch.office_lamp"}' "$HA_URL/api/services/switch/turn_on"
+```

--- a/skills/homeassistant/__init__.py
+++ b/skills/homeassistant/__init__.py
@@ -1,0 +1,5 @@
+"""Home Assistant skill package for Freja.io."""
+
+from skills.homeassistant.homeassistant_skill import get_homeassistant_command_processor
+
+__all__ = ["get_homeassistant_command_processor"]

--- a/skills/homeassistant/homeassistant_client.py
+++ b/skills/homeassistant/homeassistant_client.py
@@ -1,0 +1,122 @@
+"""HTTP client for Home Assistant REST API integration."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+
+
+class HomeAssistantClientError(Exception):
+    """Raised when a Home Assistant request fails with a user-facing message."""
+
+
+class HomeAssistantClient:
+    """Thin client for Home Assistant REST endpoints used by Freja skill commands."""
+
+    def __init__(self, ha_url: str, ha_token: str, timeout_s: int = 15) -> None:
+        """Store validated credentials and normalize URL format."""
+        self.ha_url = (ha_url or "").rstrip("/")
+        self.ha_token = (ha_token or "").strip()
+        self.timeout_s = timeout_s
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        """Execute one HTTP request and map API/network failures to stable error messages."""
+        url = f"{self.ha_url}{path}"
+        headers = {
+            "Authorization": f"Bearer {self.ha_token}",
+        }
+        if method.upper() == "POST":
+            headers["Content-Type"] = "application/json"
+
+        try:
+            with httpx.Client(timeout=self.timeout_s) as client:
+                response = client.request(method=method, url=url, headers=headers, json=payload)
+        except httpx.TimeoutException as exc:
+            raise HomeAssistantClientError("Timeout – Home Assistant svarade inte i tid.") from exc
+        except httpx.ConnectError as exc:
+            raise HomeAssistantClientError("Connection error – kunde inte nå Home Assistant.") from exc
+        except httpx.RequestError as exc:
+            raise HomeAssistantClientError("Request error – misslyckades att anropa Home Assistant.") from exc
+
+        if response.status_code in (401, 403):
+            raise HomeAssistantClientError("Unauthorized – kontrollera HA_TOKEN.")
+        if response.status_code == 404:
+            raise HomeAssistantClientError("Not found – kontrollera entity_id eller service.")
+        if response.status_code >= 400:
+            raise HomeAssistantClientError(f"Home Assistant API error ({response.status_code}).")
+
+        if not response.content:
+            return None
+
+        try:
+            return response.json()
+        except ValueError:
+            return None
+
+    def list_states(self) -> list[dict[str, Any]]:
+        """Return all states from /api/states."""
+        result = self._request("GET", "/api/states")
+        return result if isinstance(result, list) else []
+
+    def list_entities(self, domain: str | None = None) -> list[str]:
+        """Return entity IDs, optionally filtered by domain prefix."""
+        states = self.list_states()
+        entity_ids = [str(item.get("entity_id", "")) for item in states if item.get("entity_id")]
+
+        if not domain:
+            return entity_ids
+
+        normalized_domain = domain.strip().lower()
+        domain_prefix = f"{normalized_domain}."
+        return [entity_id for entity_id in entity_ids if entity_id.lower().startswith(domain_prefix)]
+
+    def get_state(self, entity_id: str) -> dict[str, Any]:
+        """Return one state object for a specific entity id."""
+        result = self._request("GET", f"/api/states/{entity_id}")
+        return result if isinstance(result, dict) else {}
+
+    def call_service(self, domain: str, service: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+        """Call a Home Assistant domain/service endpoint and return JSON response."""
+        result = self._request("POST", f"/api/services/{domain}/{service}", payload=payload)
+        if result is None:
+            return None
+        return {"result": result}
+
+    def turn_on(self, entity_id: str, **kwargs: Any) -> dict[str, Any] | None:
+        """Convenience wrapper for switch/light turn_on."""
+        domain = entity_id.split(".", 1)[0]
+        payload: dict[str, Any] = {"entity_id": entity_id, **kwargs}
+        return self.call_service(domain, "turn_on", payload)
+
+    def turn_off(self, entity_id: str) -> dict[str, Any] | None:
+        """Convenience wrapper for switch/light turn_off."""
+        domain = entity_id.split(".", 1)[0]
+        return self.call_service(domain, "turn_off", {"entity_id": entity_id})
+
+    def set_light(
+        self,
+        entity_id: str,
+        brightness_pct: int | None = None,
+        color_temp: int | None = None,
+        rgb_color: list[int] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any] | None:
+        """Convenience wrapper for richer light.turn_on payloads."""
+        payload: dict[str, Any] = {"entity_id": entity_id, **kwargs}
+        if brightness_pct is not None:
+            payload["brightness_pct"] = brightness_pct
+        if color_temp is not None:
+            payload["color_temp"] = color_temp
+        if rgb_color is not None:
+            payload["rgb_color"] = rgb_color
+        return self.call_service("light", "turn_on", payload)
+
+    def trigger_scene(self, entity_id: str) -> dict[str, Any] | None:
+        """Convenience wrapper for scene.turn_on calls."""
+        return self.call_service("scene", "turn_on", {"entity_id": entity_id})

--- a/skills/homeassistant/homeassistant_skill.py
+++ b/skills/homeassistant/homeassistant_skill.py
@@ -1,0 +1,110 @@
+"""Command parsing and orchestration for Home Assistant skill."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+from app.core.config import settings
+from skills.homeassistant.homeassistant_client import HomeAssistantClient, HomeAssistantClientError
+
+
+@dataclass
+class CommandResult:
+    """Container indicating if the command parser handled the incoming message."""
+
+    handled: bool
+    response: Optional[str] = None
+
+
+class HomeAssistantCommandProcessor:
+    """Parse and execute Home Assistant commands for Telegram and chat inputs."""
+
+    def _build_client(self) -> HomeAssistantClient:
+        """Validate configuration and return a ready API client."""
+        ha_url = (settings.HA_URL or "").strip()
+        ha_token = (settings.HA_TOKEN or "").strip()
+
+        if not ha_url or not ha_token:
+            raise HomeAssistantClientError(
+                "Home Assistant is not configured. Set HA_URL and HA_TOKEN in environment variables."
+            )
+
+        return HomeAssistantClient(ha_url=ha_url, ha_token=ha_token)
+
+    async def process_message(self, user_id: str, text: str) -> CommandResult:
+        """Process '/ha' and 'ha' command forms while keeping other messages untouched."""
+        _ = user_id  # The current HA API access is global; user-specific scope is not required.
+        normalized = text.strip()
+        lowered = normalized.lower()
+
+        if lowered.startswith("/ha"):
+            command_body = normalized[3:].strip()
+            return self._handle_command(command_body)
+
+        if lowered.startswith("ha ") or lowered == "ha":
+            command_body = normalized[2:].strip()
+            return self._handle_command(command_body)
+
+        return CommandResult(handled=False)
+
+    def _handle_command(self, command_body: str) -> CommandResult:
+        """Route Home Assistant command words to concrete client operations."""
+        if not command_body:
+            return CommandResult(True, "Svar:\nAnvänd: ha list|get|service|on|off|scene")
+
+        parts = command_body.split(maxsplit=3)
+        action = parts[0].lower()
+
+        try:
+            client = self._build_client()
+
+            if action == "list":
+                domain = parts[1] if len(parts) > 1 else None
+                entities = client.list_entities(domain=domain)
+                if not entities:
+                    return CommandResult(True, "Svar:\nInga entiteter hittades.")
+                return CommandResult(True, "Svar:\n" + "\n".join(entities))
+
+            if action == "get" and len(parts) > 1:
+                state = client.get_state(parts[1])
+                return CommandResult(True, f"Svar:\n{json.dumps(state, ensure_ascii=False, indent=2)}")
+
+            if action == "service" and len(parts) >= 3:
+                domain = parts[1]
+                service = parts[2]
+                payload_text = parts[3] if len(parts) == 4 else "{}"
+                payload = json.loads(payload_text)
+                result = client.call_service(domain=domain, service=service, payload=payload)
+                return CommandResult(True, f"Svar:\n{json.dumps(result, ensure_ascii=False, indent=2)}")
+
+            if action == "on" and len(parts) > 1:
+                result = client.turn_on(parts[1])
+                return CommandResult(True, f"Svar:\n{json.dumps(result, ensure_ascii=False, indent=2)}")
+
+            if action == "off" and len(parts) > 1:
+                result = client.turn_off(parts[1])
+                return CommandResult(True, f"Svar:\n{json.dumps(result, ensure_ascii=False, indent=2)}")
+
+            if action == "scene" and len(parts) > 1:
+                result = client.trigger_scene(parts[1])
+                return CommandResult(True, f"Svar:\n{json.dumps(result, ensure_ascii=False, indent=2)}")
+
+            return CommandResult(True, "Svar:\nOkänt HA-kommando. Exempel: ha list, ha get light.kitchen")
+
+        except json.JSONDecodeError:
+            return CommandResult(True, "Svar:\nOgiltig JSON payload i service-kommandot.")
+        except HomeAssistantClientError as exc:
+            return CommandResult(True, f"Svar:\n{exc}")
+
+
+_processor_singleton: Optional[HomeAssistantCommandProcessor] = None
+
+
+def get_homeassistant_command_processor() -> HomeAssistantCommandProcessor:
+    """Return one singleton processor instance for consistent routing behavior."""
+    global _processor_singleton
+    if _processor_singleton is None:
+        _processor_singleton = HomeAssistantCommandProcessor()
+    return _processor_singleton

--- a/tests/test_homeassistant_skill.py
+++ b/tests/test_homeassistant_skill.py
@@ -1,0 +1,144 @@
+"""Unit tests for Home Assistant skill client and command processing."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from skills.homeassistant.homeassistant_client import HomeAssistantClient, HomeAssistantClientError
+from skills.homeassistant.homeassistant_skill import HomeAssistantCommandProcessor
+
+
+class DummyResponse:
+    """Minimal response stub compatible with HomeAssistantClient expectations."""
+
+    def __init__(self, status_code: int, body=None):
+        self.status_code = status_code
+        self._body = body
+
+    @property
+    def content(self):
+        return b"" if self._body is None else b"x"
+
+    def json(self):
+        return self._body
+
+
+class DummyClient:
+    """Context-manager request stub for monkeypatching httpx.Client."""
+
+    def __init__(self, handler):
+        self.handler = handler
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def request(self, method, url, headers=None, json=None):
+        return self.handler(method, url, headers, json)
+
+
+def patch_httpx_client(monkeypatch, handler):
+    """Patch HomeAssistantClient transport layer with a deterministic handler."""
+
+    def factory(*args, **kwargs):
+        _ = args, kwargs
+        return DummyClient(handler)
+
+    monkeypatch.setattr(httpx, "Client", factory)
+
+
+def test_list_entities_with_domain_filter(monkeypatch):
+    """Entity listing should support domain-only filtering."""
+    payload = [
+        {"entity_id": "light.kitchen"},
+        {"entity_id": "switch.office_lamp"},
+        {"entity_id": "light.hall"},
+    ]
+
+    def handler(method, url, headers, body):
+        assert method == "GET"
+        assert url.endswith("/api/states")
+        return DummyResponse(200, payload)
+
+    patch_httpx_client(monkeypatch, handler)
+    client = HomeAssistantClient("http://ha.local:8123/", "token")
+
+    assert client.list_entities("light") == ["light.kitchen", "light.hall"]
+
+
+def test_get_state_ok(monkeypatch):
+    """State lookup should return Home Assistant state payload as dict."""
+    expected = {"entity_id": "light.kitchen", "state": "on", "attributes": {"brightness": 200}}
+
+    def handler(method, url, headers, body):
+        assert method == "GET"
+        assert url.endswith("/api/states/light.kitchen")
+        return DummyResponse(200, expected)
+
+    patch_httpx_client(monkeypatch, handler)
+    client = HomeAssistantClient("http://ha.local:8123", "token")
+
+    assert client.get_state("light.kitchen") == expected
+
+
+def test_call_service_ok(monkeypatch):
+    """Service calls should POST payload and return JSON body wrapped in result key."""
+    expected = [{"entity_id": "switch.office_lamp", "state": "on"}]
+
+    def handler(method, url, headers, body):
+        assert method == "POST"
+        assert headers["Content-Type"] == "application/json"
+        assert body == {"entity_id": "switch.office_lamp"}
+        assert url.endswith("/api/services/switch/turn_on")
+        return DummyResponse(200, expected)
+
+    patch_httpx_client(monkeypatch, handler)
+    client = HomeAssistantClient("http://ha.local:8123", "token")
+
+    assert client.call_service("switch", "turn_on", {"entity_id": "switch.office_lamp"}) == {"result": expected}
+
+
+def test_unauthorized_error_message(monkeypatch):
+    """401/403 should map to a stable unauthorized user-facing message."""
+
+    def handler(method, url, headers, body):
+        return DummyResponse(401, {"message": "unauthorized"})
+
+    patch_httpx_client(monkeypatch, handler)
+    client = HomeAssistantClient("http://ha.local:8123", "token")
+
+    with pytest.raises(HomeAssistantClientError, match="Unauthorized – kontrollera HA_TOKEN"):
+        client.get_state("light.kitchen")
+
+
+def test_timeout_error_message(monkeypatch):
+    """Timeout exceptions should map to a clear timeout user-facing message."""
+
+    def handler(method, url, headers, body):
+        raise httpx.TimeoutException("boom")
+
+    patch_httpx_client(monkeypatch, handler)
+    client = HomeAssistantClient("http://ha.local:8123", "token")
+
+    with pytest.raises(HomeAssistantClientError, match="Timeout"):
+        client.list_states()
+
+
+def test_command_parser_service_json_error(monkeypatch):
+    """Command parser should return a deterministic response on malformed JSON payload."""
+
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "HA_URL", "http://ha.local:8123")
+    monkeypatch.setattr(settings, "HA_TOKEN", "token")
+
+    processor = HomeAssistantCommandProcessor()
+    import asyncio
+
+    result = asyncio.run(processor.process_message("user-1", "ha service switch turn_on not-json"))
+
+    assert result.handled is True
+    assert "Ogiltig JSON payload" in (result.response or "")


### PR DESCRIPTION
### Motivation
- Provide a small, well-scoped Home Assistant integration to allow Freja to list entities, read states and call services via the Home Assistant REST API. 
- Integrate HA commands into Freja’s existing chat and Telegram flows with minimal impact on other skills and existing behavior. 

### Description
- Added a new skill package under `skills/homeassistant/` with `homeassistant_client.py` implementing `HomeAssistantClient` and `HomeAssistantClientError` and the methods `list_states`, `list_entities`, `get_state`, `call_service`, `turn_on`, `turn_off`, `set_light` and `trigger_scene`. 
- Added `homeassistant_skill.py` which provides `HomeAssistantCommandProcessor` (and `get_homeassistant_command_processor`) to parse commands like `ha list`, `ha get <entity>`, `ha service <domain> <service> <json>`, `ha on/off <entity>` and `ha scene <entity>` and returns Swedish user-facing responses. 
- Wired minimal routing: short-circuited chat-level handling in `app/services/chat_service.py` so `ha ...` commands are handled deterministically before LLM/tool flow, and registered `/ha` command handler in `app/services/telegram_service.py`. 
- Added documentation `skills/homeassistant/README.md` explaining `HA_URL` and `HA_TOKEN` setup and example commands, and a package entrypoint `skills/homeassistant/__init__.py`. 
- Implemented robust error mapping in the client for `401/403` (Unauthorized), `404` (Not found), timeouts and connection/request errors, and normalized `HA_URL` to support trailing slash variations. 

### Testing
- Ran unit tests with `PYTHONPATH=. pytest -q tests/test_homeassistant_skill.py` and they passed: `6 passed`. 
- Verified basic import/compilation with `PYTHONPATH=. python -m py_compile app/services/chat_service.py app/services/telegram_service.py skills/homeassistant/homeassistant_client.py skills/homeassistant/homeassistant_skill.py tests/test_homeassistant_skill.py` which succeeded. 
- All changes were committed together (added skill files, tests and small routing changes) and do not alter existing Strava or other skill behavior beyond additive registration and routing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2571430c83338a9b4235294562dc)