### PR TITLE
Include discovered skills in system status agents

### DIFF
--- a/app/routers/system.py
+++ b/app/routers/system.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter
 from app.core import config
 import logging
 from app.core.dependencies import get_garmin, get_strava, get_code_executor
+from app.services.tool_registry import registry
+from skills._core.skill_loader import discover_and_register_skills
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -11,21 +13,28 @@ async def get_status():
     """Returns system status including active agents"""
     
     agents = []
+    known_agent_names = set()
+
+    def add_agent(name: str, status: str, agent_type: str) -> None:
+        if name in known_agent_names:
+            return
+        agents.append({"name": name, "status": status, "type": agent_type})
+        known_agent_names.add(name)
     
     # Check Garmin (via Dependency)
     garmin_tool = get_garmin()
     if garmin_tool:
-        agents.append({"name": "Garmin Coach", "status": "Connected", "type": "health"})
+        add_agent("Garmin Coach", "Connected", "health")
     
     # Check Strava (via Dependency)
     strava_tool = get_strava()
     if strava_tool:
-        agents.append({"name": "Strava Tracker", "status": "Connected", "type": "health"})
+        add_agent("Strava Tracker", "Connected", "health")
     
     # Check Code Executor
     code_executor = get_code_executor()
     if code_executor:
-        agents.append({"name": "Code Executor", "status": "Active", "type": "system"})
+        add_agent("Code Executor", "Active", "system")
 
     # Add other known services (safely check if they exist)
     # These imports should ideally also be moved to dependencies or service registry
@@ -40,11 +49,15 @@ async def get_status():
     try:
         from app.services.proactive_service import proactive_service
         if proactive_service and hasattr(proactive_service, 'running') and proactive_service.running:
-            agents.append({"name": "Proactive Service", "status": "Active", "type": "automation"})
+            add_agent("Proactive Service", "Active", "automation")
         elif proactive_service:
-            agents.append({"name": "Proactive Service", "status": "Idle", "type": "automation"})
+            add_agent("Proactive Service", "Idle", "automation")
     except:
         pass
+
+    for manifest in discover_and_register_skills(registry):
+        skill_name = manifest.name.replace("_", " ").title()
+        add_agent(skill_name, "Loaded", "skill")
     
     return {
         "system": "operational",

--- a/tests/test_system_status_skills.py
+++ b/tests/test_system_status_skills.py
@@ -1,0 +1,28 @@
+"""Tests for system status agent reporting."""
+
+# Section: Imports
+import asyncio
+
+from app.routers import system
+from skills._core.skill_types import SkillManifest
+
+
+# Section: Tests
+def test_status_includes_discovered_skills(monkeypatch) -> None:
+    """Status endpoint should include discovered skills as active agents."""
+
+    monkeypatch.setattr(system, "get_garmin", lambda: None)
+    monkeypatch.setattr(system, "get_strava", lambda: None)
+    monkeypatch.setattr(system, "get_code_executor", lambda: None)
+
+    manifests = [
+        SkillManifest(name="weather", description="", version="1.0.0"),
+        SkillManifest(name="homeassistant", description="", version="1.0.0"),
+    ]
+    monkeypatch.setattr(system, "discover_and_register_skills", lambda _registry: manifests)
+
+    payload = asyncio.run(system.get_status())
+    names = [agent["name"] for agent in payload["agents"]]
+
+    assert "Weather" in names
+    assert "Homeassistant" in names


### PR DESCRIPTION
### Motivation
- The dashboard's "Active Agents" panel relied on `GET /status`, but the endpoint only returned hardcoded runtime integrations and did not surface skills discovered via `discover_and_register_skills`, so installed skills were not visible on the UI.

### Description
- Update `GET /status` in `app/routers/system.py` to call `discover_and_register_skills(registry)` and add each discovered `SkillManifest` as an agent with status `Loaded` and type `skill`.
- Add a small deduplication helper `add_agent(...)` (backed by `known_agent_names`) to avoid duplicate agent entries and normalize skill display names via `manifest.name.replace("_"," ").title()`.
- Add a regression test `tests/test_system_status_skills.py` that monkeypatches discovery and asserts discovered skills appear in the `/status` payload.

### Testing
- Ran `pytest -q tests/test_system_status_skills.py tests/test_skill_loader_registers_tools.py` and both tests passed (2 passed) with unrelated warnings about dependencies.
- The new test verifies that discovered skills are included in the status response and the existing registration test confirms tools are registered during discovery.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2e331528833384f0d99d103fc8a4)