### PR TITLE
Ensure Roborock tools register on startup

### DIFF
--- a/docs/roborock_skill.md
+++ b/docs/roborock_skill.md
@@ -30,3 +30,22 @@ You must set `ROBOROCK_SECRET_KEY` to a valid Fernet key.
 4. Call control tools (`status`, `start`, `pause`, `dock`).
 5. Call `roborock_rooms` and `roborock_clean_rooms`.
 6. Call `roborock_consumables`, `roborock_maps`, and `roborock_map_image`.
+
+## Chat usage examples
+
+Freja can call Roborock tools from natural language prompts such as:
+
+- "Starta dammsugaren" → maps to `roborock_start`.
+- "Pausa dammsugaren" → maps to `roborock_pause`.
+- "Skicka dammsugaren till dockan" → maps to `roborock_dock`.
+
+## Required environment variables
+
+- `ROBOROCK_SECRET_KEY`: Fernet key used to encrypt credentials in SQLite.
+- `USER_ID` (optional): Freja user partition used for credential lookup. Defaults to the configured app user.
+
+Generate a key with:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```

--- a/main.py
+++ b/main.py
@@ -7,9 +7,10 @@ from app.core.logging import logger
 from app.services.proactive_service import init_proactive_service
 from contextlib import asynccontextmanager
 
-# Import tools to register them
-# Import tools to register them
-# import app.tools.basic_tools  # Legacy tools, superseded by app.tools.implementations
+# Section: Tool bootstrap imports
+# Importing this module at app startup ensures all auto-discovered skill tools,
+# including Roborock, are registered in the shared ToolRegistry before first chat.
+import app.tools.implementations  # noqa: F401
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/tests/test_skill_loader_registers_tools.py
+++ b/tests/test_skill_loader_registers_tools.py
@@ -7,10 +7,11 @@ from skills._core.skill_loader import discover_and_register_skills
 
 # Section: Tests
 def test_skill_loader_registers_expected_tools() -> None:
-    """Discovering skills should register weather, garmin, and strava tools."""
+    """Discovering skills should register weather, garmin, strava, and roborock tools."""
     registry = ToolRegistry()
     discover_and_register_skills(registry)
 
     assert "get_weather" in registry._tools
     assert "get_garmin_health" in registry._tools
     assert "get_strava_activities" in registry._tools
+    assert "roborock_start" in registry._tools


### PR DESCRIPTION
### Motivation
- Guarantee that the Roborock skill is loaded and its tools (e.g. `roborock_start`) are available to the chat service at application startup so Freja can invoke commands like "Starta dammsugaren" reliably.
- Avoid relying on delayed or implicit imports by ensuring the auto-discovery bootstrap runs during app initialization without changing other skill logic or UI.

### Description
- Import the implementations bootstrap at startup by adding `import app.tools.implementations` to `main.py` so `discover_and_register_skills` runs early and populates the `ToolRegistry` (no other logic changes). 
- Update the unit test `tests/test_skill_loader_registers_tools.py` to assert that `roborock_start` is registered by the skill loader so the registration path is validated in CI.
- Add short usage examples and required environment variable guidance to `docs/roborock_skill.md` showing example Swedish phrases mapped to `roborock_*` tools and noting `ROBOROCK_SECRET_KEY` and optional `USER_ID` requirements.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_skill_loader_registers_tools.py tests/test_roborock_skill.py`, which completed successfully with all tests passing.
- Existing Roborock unit tests (`tests/test_roborock_skill.py`) continued to pass, validating storage encryption and subprocess wrapper behavior.

Changed files: `main.py` (ensure tools bootstrap import), `tests/test_skill_loader_registers_tools.py` (assert `roborock_start`), `docs/roborock_skill.md` (usage and env var notes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f42734fa083339d5c4cd938eb1cc1)