### PR TITLE
Lägg till Home Assistant och Roborock fält i System Configuration

### DIFF
--- a/client/src/components/Settings.jsx
+++ b/client/src/components/Settings.jsx
@@ -133,6 +133,10 @@ const Settings = () => {
             title: "Integrations",
             icon: <ActivityIcon />,
             items: [
+                { key: "HA_URL", label: "Home Assistant URL", type: "text", desc: "e.g. http://homeassistant.local:8123" },
+                { key: "HA_TOKEN", label: "Home Assistant Token", type: "password", desc: "Long-lived access token from Home Assistant" },
+                { key: "ROBOROCK_SECRET_KEY", label: "Roborock Secret Key", type: "password", desc: "Fernet key for encrypted Roborock credentials" },
+                { key: "USER_ID", label: "Roborock User ID", type: "text", desc: "Credential partition key for Roborock data (optional override)" },
                 { key: "GARMIN_EMAIL", label: "Garmin Email", type: "text" },
                 { key: "GARMIN_PASSWORD", label: "Garmin Password", type: "password" },
                 {


### PR DESCRIPTION
### Motivation
- Lägg till saknade konfigurationsfält som Home Assistant och Roborock-skills för att användare ska kunna ange `HA_URL`, `HA_TOKEN`, `ROBOROCK_SECRET_KEY` och `USER_ID` från System Configuration-gränssnittet.

### Description
- Uppdaterade `client/src/components/Settings.jsx` och la till fyra nya fält i sektionen "Integrations": `HA_URL`, `HA_TOKEN`, `ROBOROCK_SECRET_KEY` och `USER_ID` med engelska labels/descriptions.

### Testing
- Byggde frontend med `npm --prefix client run build`, startade dev-servern med `npm --prefix client run dev -- --host 0.0.0.0 --port 4173` och fångade en Playwright-screenshot för visuell verifiering; alla steg lyckades.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f44880d808333a2f017c77238cf5f)