### PR TITLE
Support HAURL/HATOKEN env aliases and update Home Assistant config error text

### DIFF
--- a/skills/homeassistant/homeassistant_skill.py
+++ b/skills/homeassistant/homeassistant_skill.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from typing import Optional
 
@@ -23,12 +24,12 @@ class HomeAssistantCommandProcessor:
 
     def _build_client(self) -> HomeAssistantClient:
         """Validate configuration and return a ready API client."""
-        ha_url = (settings.HA_URL or "").strip()
-        ha_token = (settings.HA_TOKEN or "").strip()
+        ha_url = (settings.HA_URL or os.getenv("HAURL") or "").strip()
+        ha_token = (settings.HA_TOKEN or os.getenv("HATOKEN") or "").strip()
 
         if not ha_url or not ha_token:
             raise HomeAssistantClientError(
-                "Home Assistant is not configured. Set HA_URL and HA_TOKEN in environment variables."
+                "Home Assistant is not configured. Set HAURL and HATOKEN in environment variables."
             )
 
         return HomeAssistantClient(ha_url=ha_url, ha_token=ha_token)

--- a/tests/test_homeassistant_skill.py
+++ b/tests/test_homeassistant_skill.py
@@ -142,3 +142,50 @@ def test_command_parser_service_json_error(monkeypatch):
 
     assert result.handled is True
     assert "Ogiltig JSON payload" in (result.response or "")
+
+
+def test_command_parser_missing_config_message(monkeypatch):
+    """Missing HA config should use the documented variable names in response."""
+
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "HA_URL", None)
+    monkeypatch.setattr(settings, "HA_TOKEN", None)
+    monkeypatch.delenv("HAURL", raising=False)
+    monkeypatch.delenv("HATOKEN", raising=False)
+
+    processor = HomeAssistantCommandProcessor()
+    import asyncio
+
+    result = asyncio.run(processor.process_message("user-1", "ha list"))
+
+    assert result.handled is True
+    assert result.response == (
+        "Svar:\nHome Assistant is not configured. Set HAURL and HATOKEN in environment variables."
+    )
+
+
+def test_command_parser_reads_legacy_haurl_hatoken_aliases(monkeypatch):
+    """Command parser should accept HAURL/HATOKEN aliases when canonical keys are empty."""
+
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "HA_URL", None)
+    monkeypatch.setattr(settings, "HA_TOKEN", None)
+    monkeypatch.setenv("HAURL", "http://ha.local:8123")
+    monkeypatch.setenv("HATOKEN", "token")
+
+    def handler(method, url, headers, body):
+        assert method == "GET"
+        assert url.endswith("/api/states")
+        return DummyResponse(200, [])
+
+    patch_httpx_client(monkeypatch, handler)
+
+    processor = HomeAssistantCommandProcessor()
+    import asyncio
+
+    result = asyncio.run(processor.process_message("user-1", "ha list"))
+
+    assert result.handled is True
+    assert result.response == "Svar:\nInga entiteter hittades."


### PR DESCRIPTION
### Motivation
- Ensure the Home Assistant skill can still be used when legacy environment variable names (`HAURL`/`HATOKEN`) are present instead of the canonical `HA_URL`/`HA_TOKEN`.
- Make the user-facing configuration error message match the variable names that are expected in environments using the legacy aliases.

### Description
- Add `os.getenv("HAURL")` and `os.getenv("HATOKEN")` fallbacks when constructing the Home Assistant client so legacy env vars are accepted (`skills/homeassistant/homeassistant_skill.py`).
- Update the configuration error string to state `Set HAURL and HATOKEN in environment variables.` for clarity and consistency (`skills/homeassistant/homeassistant_skill.py`).
- Add unit tests that verify the new error message when config is missing and that commands work when only the legacy `HAURL`/`HATOKEN` env vars are set (`tests/test_homeassistant_skill.py`).
- Small test fixes to use `monkeypatch.setenv`/`monkeypatch.delenv` and add the import of `os` where required.

### Testing
- Ran `pytest -q tests/test_homeassistant_skill.py` and all tests passed; result: `8 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900480e68483338d40fd702f16e55f)