### PR TITLE
Fix Home Assistant skill to use DB-backed credentials

### DIFF
--- a/skills/homeassistant/homeassistant_skill.py
+++ b/skills/homeassistant/homeassistant_skill.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 
-from app.core.config import settings
+from app.core.config import get_credential, settings
 from skills.homeassistant.homeassistant_client import HomeAssistantClient, HomeAssistantClientError
 
 
@@ -24,12 +24,18 @@ class HomeAssistantCommandProcessor:
 
     def _build_client(self) -> HomeAssistantClient:
         """Validate configuration and return a ready API client."""
-        ha_url = (settings.HA_URL or os.getenv("HAURL") or "").strip()
-        ha_token = (settings.HA_TOKEN or os.getenv("HATOKEN") or "").strip()
+        ha_url = (
+            get_credential("HA_URL")
+            or get_credential("HA_BASE_URL")
+            or settings.HA_URL
+            or os.getenv("HAURL")
+            or ""
+        ).strip()
+        ha_token = (get_credential("HA_TOKEN") or settings.HA_TOKEN or os.getenv("HATOKEN") or "").strip()
 
         if not ha_url or not ha_token:
             raise HomeAssistantClientError(
-                "Home Assistant is not configured. Set HAURL and HATOKEN in environment variables."
+                "Home Assistant is not configured. Set HA_URL and HA_TOKEN in Settings or environment variables."
             )
 
         return HomeAssistantClient(ha_url=ha_url, ha_token=ha_token)

--- a/tests/test_homeassistant_skill.py
+++ b/tests/test_homeassistant_skill.py
@@ -161,8 +161,42 @@ def test_command_parser_missing_config_message(monkeypatch):
 
     assert result.handled is True
     assert result.response == (
-        "Svar:\nHome Assistant is not configured. Set HAURL and HATOKEN in environment variables."
+        "Svar:\nHome Assistant is not configured. Set HA_URL and HA_TOKEN in Settings or environment variables."
     )
+
+
+def test_command_parser_reads_db_backed_ha_base_url(monkeypatch):
+    """Command parser should read HA_BASE_URL/HA_TOKEN from DB-backed credentials."""
+
+    import skills.homeassistant.homeassistant_skill as ha_skill_module
+
+    monkeypatch.delenv("HAURL", raising=False)
+    monkeypatch.delenv("HATOKEN", raising=False)
+
+    def fake_get_credential(key, fallback=None):
+        values = {
+            "HA_URL": "",
+            "HA_BASE_URL": "http://ha.local:8123",
+            "HA_TOKEN": "token",
+        }
+        return values.get(key, fallback or "")
+
+    monkeypatch.setattr(ha_skill_module, "get_credential", fake_get_credential)
+
+    def handler(method, url, headers, body):
+        assert method == "GET"
+        assert url.endswith("/api/states")
+        return DummyResponse(200, [])
+
+    patch_httpx_client(monkeypatch, handler)
+
+    processor = HomeAssistantCommandProcessor()
+    import asyncio
+
+    result = asyncio.run(processor.process_message("user-1", "ha list"))
+
+    assert result.handled is True
+    assert result.response == "Svar:\nInga entiteter hittades."
 
 
 def test_command_parser_reads_legacy_haurl_hatoken_aliases(monkeypatch):


### PR DESCRIPTION
### Motivation
- Ensure Home Assistant credentials stored in the DB/Settings are used before falling back to environment variables so saved `HA_URL`/`HA_TOKEN` (and legacy `HA_BASE_URL`) actually work.
- Preserve backward compatibility with the legacy env aliases `HAURL`/`HATOKEN` while making the missing-config message point to canonical setting names.

### Description
- Switched credential resolution in `skills/homeassistant/homeassistant_skill.py` to use `get_credential(...)` first and then `settings` and env vars, including fallback to the legacy `HA_BASE_URL` key, by importing `get_credential` from `app.core.config` and updating the `_build_client` logic to read `HA_URL`/`HA_BASE_URL` and `HA_TOKEN` via DB-first lookup and fallbacks.
- Updated the user-facing missing-configuration message to reference `HA_URL` and `HA_TOKEN` and indicate they can be set in Settings or environment variables.
- Updated the test `test_command_parser_missing_config_message` to expect the new message and added `test_command_parser_reads_db_backed_ha_base_url` to verify DB-backed `HA_BASE_URL` + `HA_TOKEN` are used by the command processor.
- Files changed: `skills/homeassistant/homeassistant_skill.py`, `tests/test_homeassistant_skill.py`.

### Testing
- Ran `pytest -q tests/test_homeassistant_skill.py` and all tests passed: `9 passed in 0.39s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900ef9c3308333ad5a1b4ba607c5af)