### PR TITLE
Update Home Assistant missing-config message to HAURL/HATOKEN

### DIFF
--- a/skills/homeassistant/homeassistant_skill.py
+++ b/skills/homeassistant/homeassistant_skill.py
@@ -35,7 +35,7 @@ class HomeAssistantCommandProcessor:
 
         if not ha_url or not ha_token:
             raise HomeAssistantClientError(
-                "Home Assistant is not configured. Set HA_URL and HA_TOKEN in Settings or environment variables."
+                "Home Assistant is not configured. Set HAURL and HATOKEN in environment variables."
             )
 
         return HomeAssistantClient(ha_url=ha_url, ha_token=ha_token)

--- a/tests/test_homeassistant_skill.py
+++ b/tests/test_homeassistant_skill.py
@@ -161,7 +161,7 @@ def test_command_parser_missing_config_message(monkeypatch):
 
     assert result.handled is True
     assert result.response == (
-        "Svar:\nHome Assistant is not configured. Set HA_URL and HA_TOKEN in Settings or environment variables."
+        "Svar:\nHome Assistant is not configured. Set HAURL and HATOKEN in environment variables."
     )
 
 


### PR DESCRIPTION
### Motivation
- Align the Home Assistant skill's user-facing missing-configuration message with the legacy environment variable names actually checked by the code (`HAURL`/`HATOKEN`) to avoid user confusion.

### Description
- Changed the missing-config error text in `skills/homeassistant/homeassistant_skill.py` to: `Home Assistant is not configured. Set HAURL and HATOKEN in environment variables.`
- Updated the corresponding unit test expectation in `tests/test_homeassistant_skill.py` to match the new message.

### Testing
- Ran `pytest -q tests/test_homeassistant_skill.py` and the suite passed with `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990167e49fc8333a912c7db3b0e90a5)