### PR TITLE
Localize Home Assistant missing-config response to Swedish

### DIFF
--- a/skills/homeassistant/homeassistant_skill.py
+++ b/skills/homeassistant/homeassistant_skill.py
@@ -35,7 +35,7 @@ class HomeAssistantCommandProcessor:
 
         if not ha_url or not ha_token:
             raise HomeAssistantClientError(
-                "Home Assistant is not configured. Set HA_URL and HA_TOKEN in Settings or environment variables."
+                "Home Assistant är inte konfigurerat. Sätt HAURL och HATOKEN i miljövariabler."
             )
 
         return HomeAssistantClient(ha_url=ha_url, ha_token=ha_token)

--- a/tests/test_homeassistant_skill.py
+++ b/tests/test_homeassistant_skill.py
@@ -161,7 +161,7 @@ def test_command_parser_missing_config_message(monkeypatch):
 
     assert result.handled is True
     assert result.response == (
-        "Svar:\nHome Assistant is not configured. Set HA_URL and HA_TOKEN in Settings or environment variables."
+        "Svar:\nHome Assistant är inte konfigurerat. Sätt HAURL och HATOKEN i miljövariabler."
     )
 
 


### PR DESCRIPTION
### Motivation
- Freja.io user-facing replies should be in Swedish, including error/missing-configuration messages for skills. 
- Keep the environment variable names explicit (`HAURL` and `HATOKEN`) since those are the names the code actually checks.

### Description
- Updated the missing-configuration message in `skills/homeassistant/homeassistant_skill.py` to: `Home Assistant är inte konfigurerat. Sätt HAURL och HATOKEN i miljövariabler.`
- Updated the corresponding unit test expectation in `tests/test_homeassistant_skill.py` to match the new Swedish message.
- Changes were committed on the working branch.

### Testing
- Ran `pytest -q tests/test_homeassistant_skill.py` and the test suite passed with `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990167e49fc8333a912c7db3b0e90a5)