### PR TITLE
Add pfSense log monitoring skill with anomaly reporting

### DIFF
--- a/app/tools/definitions.py
+++ b/app/tools/definitions.py
@@ -70,3 +70,10 @@ class RoborockMapImageInput(BaseModel):
 
     device_id: Optional[str] = Field(None, description="Target Roborock device id.")
     output_format: str = Field("png", description="Output format. Currently only png is supported.")
+
+
+class AnalyzePfSenseLogs(BaseModel):
+    """Analyze pfSense logs and return a report with anomaly warnings."""
+
+    limit: int = Field(200, description="Number of log lines to sample from pfSense.")
+    lookback_minutes: int = Field(60, description="Time window in minutes used to identify recent spikes.")

--- a/app/tools/pfsense_core.py
+++ b/app/tools/pfsense_core.py
@@ -1,0 +1,198 @@
+"""Core pfSense log analysis helpers powered by the pfrest API."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import requests
+
+
+@dataclass(slots=True)
+class PfSenseConfig:
+    """Runtime configuration for pfSense API access."""
+
+    base_url: str
+    api_key: str
+    verify_tls: bool
+
+
+def _get_config() -> PfSenseConfig:
+    base_url = os.getenv("PFSENSE_API_URL", "").strip().rstrip("/")
+    api_key = os.getenv("PFSENSE_API_KEY", "").strip()
+    verify_tls = os.getenv("PFSENSE_VERIFY_TLS", "true").strip().lower() not in {"0", "false", "no"}
+    return PfSenseConfig(base_url=base_url, api_key=api_key, verify_tls=verify_tls)
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+
+    raw = value.strip()
+    try:
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        for fmt in ("%b %d %H:%M:%S", "%Y-%m-%d %H:%M:%S"):
+            try:
+                parsed = datetime.strptime(raw, fmt)
+                if parsed.year == 1900:
+                    parsed = parsed.replace(year=datetime.now(tz=timezone.utc).year)
+                return parsed.replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+    return None
+
+
+def _classify_log_entry(entry: dict[str, Any]) -> str:
+    for field in ("process", "program", "subsystem", "source", "service"):
+        value = entry.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+
+    message = str(entry.get("message") or entry.get("msg") or "").lower()
+    if "blocked" in message or "deny" in message:
+        return "firewall-block"
+    if "login" in message or "auth" in message:
+        return "authentication"
+    if "error" in message or "fail" in message:
+        return "error"
+    return "unknown"
+
+
+def _extract_log_entries(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        for key in ("data", "logs", "rows", "items", "result"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _summarize(entries: list[dict[str, Any]], lookback_minutes: int) -> dict[str, Any]:
+    now = datetime.now(tz=timezone.utc)
+    cutoff = now - timedelta(minutes=lookback_minutes)
+
+    categories: Counter[str] = Counter()
+    severity: Counter[str] = Counter()
+    anomalies: list[str] = []
+
+    recent_events = 0
+    historical_events = 0
+
+    for entry in entries:
+        category = _classify_log_entry(entry)
+        categories[category] += 1
+
+        level = str(entry.get("severity") or entry.get("level") or "info").lower().strip()
+        severity[level] += 1
+
+        timestamp = _parse_timestamp(entry.get("timestamp") or entry.get("time") or entry.get("date"))
+        if timestamp and timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+
+        if timestamp and timestamp >= cutoff:
+            recent_events += 1
+        else:
+            historical_events += 1
+
+        message = str(entry.get("message") or entry.get("msg") or "")
+        if "kernel panic" in message.lower() or "out of memory" in message.lower():
+            anomalies.append(f"Critical pattern detected: {message[:140]}")
+
+    if recent_events >= max(20, historical_events * 0.35):
+        anomalies.append(
+            "Event-rate spike detected in the most recent window "
+            f"({recent_events} recent events vs {historical_events} older events)."
+        )
+
+    if severity.get("error", 0) + severity.get("critical", 0) > max(5, int(len(entries) * 0.2)):
+        anomalies.append("High ratio of error/critical events in sampled logs.")
+
+    sorted_categories = categories.most_common(5)
+    sorted_severity = severity.most_common()
+
+    return {
+        "sampled_events": len(entries),
+        "lookback_minutes": lookback_minutes,
+        "recent_events": recent_events,
+        "historical_events": historical_events,
+        "top_categories": sorted_categories,
+        "severity_distribution": sorted_severity,
+        "anomalies": anomalies,
+    }
+
+
+def _format_report(summary: dict[str, Any]) -> str:
+    lines = [
+        "pfSense Log Report",
+        f"- Sampled events: {summary['sampled_events']}",
+        f"- Analysis window: last {summary['lookback_minutes']} minutes",
+        f"- Recent events: {summary['recent_events']}",
+        f"- Older events: {summary['historical_events']}",
+        "- Top categories:",
+    ]
+
+    for category, count in summary["top_categories"]:
+        lines.append(f"  - {category}: {count}")
+
+    lines.append("- Severity distribution:")
+    for level, count in summary["severity_distribution"]:
+        lines.append(f"  - {level}: {count}")
+
+    if summary["anomalies"]:
+        lines.append("- Alerts:")
+        for warning in summary["anomalies"]:
+            lines.append(f"  - ⚠️ {warning}")
+    else:
+        lines.append("- Alerts: No anomalies detected in the sampled logs.")
+
+    return "\n".join(lines)
+
+
+def _fetch_logs_sync(limit: int) -> list[dict[str, Any]]:
+    config = _get_config()
+    if not config.base_url or not config.api_key:
+        raise RuntimeError(
+            "Missing pfSense API configuration. Set PFSENSE_API_URL and PFSENSE_API_KEY."
+        )
+
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Authorization": f"Bearer {config.api_key}",
+            "Accept": "application/json",
+        }
+    )
+
+    endpoints = [
+        f"{config.base_url}/api/v2/status/log/system",
+        f"{config.base_url}/api/v1/status/log/system",
+        f"{config.base_url}/api/status/log/system",
+    ]
+
+    for endpoint in endpoints:
+        response = session.get(endpoint, params={"limit": limit}, timeout=20, verify=config.verify_tls)
+        if response.status_code == 404:
+            continue
+        response.raise_for_status()
+        return _extract_log_entries(response.json())
+
+    raise RuntimeError("Could not find a working pfSense system log endpoint in pfrest.")
+
+
+async def analyze_pfsense_logs(limit: int = 200, lookback_minutes: int = 60) -> str:
+    """Fetch pfSense logs and build a short anomaly report."""
+    entries = await asyncio.to_thread(_fetch_logs_sync, limit)
+    summary = _summarize(entries, lookback_minutes=lookback_minutes)
+    return _format_report(summary)
+
+
+__all__ = ["analyze_pfsense_logs", "_summarize"]

--- a/skills/README.md
+++ b/skills/README.md
@@ -83,6 +83,17 @@ Styr ditt smarta hem via Home Assistant.
     *   `ha on light.vardagsrum`
     *   `ha list switch`
 
+
+### 🔐 pfSense
+Analyserar pfSense-loggar via pfrest API och flaggar avvikelser.
+
+*   **Verktyg:**
+    *   `analyze_pfsense_logs(limit, lookback_minutes)`: Hämtar loggar, bygger rapport och varnar vid avvikande mönster.
+
+*   **Användning:**
+    *   "Analysera pfSense-loggar senaste timmen."
+    *   "Finns det något onormalt i brandväggsloggarna?"
+
 ### ☀️ Väder
 Hämtar väderprognoser.
 

--- a/skills/pfsense/SKILL.md
+++ b/skills/pfsense/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: pfsense-log-monitor
+description: Use this skill when a user wants to monitor pfSense logs through pfrest, generate incident reports, or detect anomalous activity.
+---
+
+# pfSense Log Monitor Skill
+
+## Purpose
+Use pfrest endpoints to read pfSense logs, summarize normal behavior, and produce alerts when unusual patterns occur.
+
+## Configuration
+Before using tools, verify these environment variables:
+
+- `PFSENSE_API_URL` (example: `https://pfsense.local`)
+- `PFSENSE_API_KEY`
+- `PFSENSE_VERIFY_TLS` (`true` or `false`, optional)
+
+## Workflow
+1. Call `analyze_pfsense_logs` with a relevant `limit` and `lookback_minutes`.
+2. Return the report in Swedish to the user, but keep technical labels and alert text in English.
+3. If anomalies are present, include clear next steps (for example: check firewall rules, VPN auth attempts, WAN health).
+4. If no anomalies are present, state that monitoring should continue and suggest running periodic checks.
+
+## Recommended defaults
+- `limit: 200`
+- `lookback_minutes: 60`
+
+Increase `limit` to 500+ for incident analysis.

--- a/skills/pfsense/__init__.py
+++ b/skills/pfsense/__init__.py
@@ -1,0 +1,20 @@
+"""pfSense skill package for Freja.io."""
+
+from skills._core.skill_types import SkillManifest
+from skills.pfsense.tools import register_tools
+
+
+SKILL = SkillManifest(
+    name="pfsense",
+    description="Provides pfSense log analysis and anomaly alerting via pfrest API.",
+    version="1.0.0",
+    tools=["analyze_pfsense_logs"],
+)
+
+
+def register(registry) -> None:
+    """Register all tools provided by the pfSense skill."""
+    register_tools(registry)
+
+
+__all__ = ["SKILL", "register"]

--- a/skills/pfsense/tools.py
+++ b/skills/pfsense/tools.py
@@ -1,0 +1,24 @@
+"""pfSense tool registrations exposed by the pfSense skill."""
+
+from app.services.tool_registry import ToolRegistry
+from app.tools.definitions import AnalyzePfSenseLogs
+
+
+def register_tools(registry: ToolRegistry) -> None:
+    """Register pfSense tools in the shared tool registry."""
+
+    @registry.register(
+        name="analyze_pfsense_logs",
+        description=(
+            "Fetches pfSense system logs using pfrest, builds a report, and flags unusual patterns "
+            "such as event spikes or critical errors."
+        ),
+        args_schema=AnalyzePfSenseLogs,
+    )
+    async def analyze_pfsense_logs_impl(limit: int = 200, lookback_minutes: int = 60) -> str:
+        from app.tools.pfsense_core import analyze_pfsense_logs
+
+        try:
+            return await analyze_pfsense_logs(limit=limit, lookback_minutes=lookback_minutes)
+        except Exception as exc:
+            return f"Failed to analyze pfSense logs: {exc}"

--- a/tests/test_pfsense_skill.py
+++ b/tests/test_pfsense_skill.py
@@ -1,0 +1,36 @@
+"""Tests for pfSense skill registration and reporting."""
+
+import asyncio
+
+from app.services.tool_registry import ToolRegistry
+from skills._core.skill_loader import discover_and_register_skills
+
+
+def test_pfsense_tool_is_registered() -> None:
+    """Auto-discovery should register pfSense analysis tool."""
+    registry = ToolRegistry()
+    discover_and_register_skills(registry)
+
+    assert "analyze_pfsense_logs" in registry._tools
+
+
+def test_pfsense_tool_returns_report_with_mock(monkeypatch) -> None:
+    """Tool should return report text when core function is mocked."""
+    registry = ToolRegistry()
+    discover_and_register_skills(registry)
+
+    async def fake_report(limit: int = 200, lookback_minutes: int = 60) -> str:
+        return (
+            "pfSense Log Report\n"
+            "- Sampled events: 10\n"
+            "- Alerts:\n"
+            "  - ⚠️ Event-rate spike detected"
+        )
+
+    monkeypatch.setattr("app.tools.pfsense_core.analyze_pfsense_logs", fake_report)
+
+    result = asyncio.run(registry.execute("analyze_pfsense_logs", {"limit": 10, "lookback_minutes": 30}))
+
+    assert isinstance(result, str)
+    assert "pfSense Log Report" in result
+    assert "Alerts" in result


### PR DESCRIPTION
### Motivation
- Provide a reusable Freja skill to monitor pfSense via the pfrest API, analyze system logs, and surface anomalous activity. 
- Enable automated short reports and alerts that help identify event-rate spikes, elevated error ratios, and critical message patterns.

### Description
- Add a new `pfsense` skill package (`skills/pfsense/__init__.py`, `skills/pfsense/tools.py`, `skills/pfsense/SKILL.md`) which registers the `analyze_pfsense_logs` tool. 
- Implement core log analysis in `app/tools/pfsense_core.py` that reads pfSense config from `PFSENSE_API_URL`/`PFSENSE_API_KEY`/`PFSENSE_VERIFY_TLS`, queries multiple pfrest endpoints, extracts and classifies entries, summarizes categories/severity, and formats a concise report with anomalies. 
- Add a Pydantic tool schema `AnalyzePfSenseLogs` to `app/tools/definitions.py` with `limit` and `lookback_minutes` parameters and update the skills overview (`skills/README.md`). 
- Add unit tests (`tests/test_pfsense_skill.py`) to verify tool registration and mock-based report behavior, and adjust datetime handling to use `timezone.utc` for compatibility.

### Testing
- Ran `pytest -q tests/test_pfsense_skill.py tests/test_skill_loader_registers_tools.py` initially, which failed due to missing dependencies; installed dependencies with `python -m pip install -r requirements.txt`. 
- Re-ran `pytest -q tests/test_pfsense_skill.py tests/test_skill_loader_registers_tools.py` after fixes and dependency install, and the focused suite passed (`3 passed`, `3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699412e7ac6083339ae27fd4ccdeaff3)