### PR TITLE
Enhance cybersecurity skill: scope controls, credential handling, and reporting improvements

### DIFF
--- a/skills/cybersecurity/README.md
+++ b/skills/cybersecurity/README.md
@@ -6,7 +6,9 @@ This skill is designed for **authorized defensive security work**.
 
 - Build a safe assessment blueprint before a penetration test.
 - Enforce authorization checks.
+- Improve finding quality and vulnerability coverage.
 - Generate remediation-focused reports after validated findings.
+- Handle credential-exposure evidence safely without disclosing secrets.
 
 ## Included tools
 
@@ -16,18 +18,26 @@ Creates a legally constrained and operationally safe plan.
 **Important behavior**:
 - If `authorization_confirmed` is `false`, the tool refuses testing instructions and returns defensive prep steps.
 - If anonymized routing is requested, it recommends auditable, company-controlled routing instead of attacker-style anonymity.
+- Supports explicit scoping (`in_scope_assets`, `out_of_scope_assets`) and depth controls for production/non-production testing.
+- Improves effectiveness by adding a vulnerability coverage matrix across access control, API/input, data protection, infrastructure, and supply chain.
+- Explicitly prohibits collecting or reporting plaintext credentials.
 
 ### `cybersecurity_generate_report`
 Creates a concise report with:
 - Executive summary
+- Overall risk rating
 - Findings section
+- Credential exposure evidence section (redacted only)
+- Validation quality standard
 - Remediation program
 - Prevention checklist
 
-## Example workflow
+## Recommended usage pattern
 
 1. Confirm written authorization and in-scope assets.
-2. Run `cybersecurity_assessment_blueprint`.
+2. Run `cybersecurity_assessment_blueprint` with scope details and allowed testing mode.
 3. Execute approved checks externally (outside this skill).
-4. Collect findings and pass them to `cybersecurity_generate_report`.
-5. Track remediation and perform retest.
+4. Collect findings with severity + confidence + evidence.
+5. If credential exposure exists, include only redacted and non-reusable proof in `credential_evidence_markdown`.
+6. Run `cybersecurity_generate_report` and set a retest deadline.
+7. Track remediation and perform retest closure.

--- a/skills/cybersecurity/SKILL.md
+++ b/skills/cybersecurity/SKILL.md
@@ -11,7 +11,15 @@ Use this skill only for authorized security engagements.
 
 - Require explicit written authorization before any testing support.
 - Never provide stealth, persistence, phishing, credential theft, or exploitation playbooks.
+- Never collect, retrieve, store, or disclose plaintext passwords or reusable secrets.
 - Keep recommendations focused on risk reduction, validation hygiene, and remediation.
+
+## Effectiveness requirements
+
+- Prefer authenticated testing (with least-privileged approved accounts) when allowed to improve detection of access-control flaws.
+- Track explicit in-scope and out-of-scope assets to prevent scope drift.
+- Require reproducible evidence and confidence rating per finding to reduce false positives.
+- Map findings to recognized standards (OWASP ASVS/CWE/CVSS) for consistent prioritization.
 
 ## Tools
 
@@ -22,16 +30,28 @@ Input:
 - authorization_confirmed
 - testing_intensity
 - anonymized_routing_requested
+- in_scope_assets
+- out_of_scope_assets
+- authenticated_testing_allowed
+- production_target
+- primary_stack
 
 Behavior:
-- Refuses offensive guidance without authorization.
+- Refuses testing guidance without authorization.
 - Returns a constrained, auditable testing blueprint when authorization is confirmed.
+- Adds vulnerability coverage controls and stack-aware focus areas.
 
 ### `cybersecurity_generate_report`
 Input:
 - target
 - summary
 - findings_markdown
+- overall_risk_rating
+- retest_required_within_days
+- credential_exposure_observed
+- credential_evidence_markdown
 
 Behavior:
 - Produces a practical, remediation-first report suitable for technical and business stakeholders.
+- Enforces quality gates for findings (severity, confidence, evidence, reproducibility).
+- Refuses report content that appears to include plaintext credentials.

--- a/skills/cybersecurity/tools.py
+++ b/skills/cybersecurity/tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -23,6 +24,26 @@ class AssessmentBlueprintSchema(BaseModel):
         False,
         description="Whether anonymized routing (for example WireGuard) was requested.",
     )
+    in_scope_assets: list[str] = Field(
+        default_factory=list,
+        description="Explicit in-scope hosts, domains, APIs, repositories, and cloud accounts.",
+    )
+    out_of_scope_assets: list[str] = Field(
+        default_factory=list,
+        description="Assets that must never be touched during testing.",
+    )
+    authenticated_testing_allowed: bool = Field(
+        False,
+        description="Whether authenticated testing is allowed for approved accounts.",
+    )
+    production_target: bool = Field(
+        True,
+        description="Whether testing is against production assets.",
+    )
+    primary_stack: list[str] = Field(
+        default_factory=list,
+        description="Technology hints, e.g. nginx, react, fastapi, aws, postgresql.",
+    )
 
 
 class ReportSchema(BaseModel):
@@ -31,6 +52,44 @@ class ReportSchema(BaseModel):
     findings_markdown: str = Field(
         ..., description="Markdown bullet list of findings with severity and evidence."
     )
+    overall_risk_rating: Literal["critical", "high", "medium", "low"] = Field(
+        "medium",
+        description="Overall risk rating based on validated findings.",
+    )
+    retest_required_within_days: int = Field(
+        30,
+        ge=1,
+        le=365,
+        description="Target deadline for fix validation retest.",
+    )
+    credential_exposure_observed: bool = Field(
+        False,
+        description="Whether credential exposure risk was validated during authorized testing.",
+    )
+    credential_evidence_markdown: str = Field(
+        "",
+        description=(
+            "Redacted evidence only (for example masked samples, hash indicators, logs). "
+            "Never include plaintext passwords or reusable secrets."
+        ),
+    )
+
+
+def _contains_plaintext_passwords(text: str) -> bool:
+    """Detect likely plaintext password disclosure in evidence text."""
+    if not text.strip():
+        return False
+
+    redaction_markers = ["[redacted]", "<redacted>", "****", "*****", "xxxx"]
+    lower_text = text.lower()
+    if any(marker in lower_text for marker in redaction_markers):
+        return False
+
+    patterns = [
+        r"(?i)(password|passphrase|pwd)\s*[:=]\s*[^\s`]+",
+        r"(?i)(login|credential)\s*[:=]\s*[^\s`]+",
+    ]
+    return any(re.search(pattern, text) for pattern in patterns)
 
 
 def cybersecurity_assessment_blueprint_impl(
@@ -39,6 +98,11 @@ def cybersecurity_assessment_blueprint_impl(
     authorization_confirmed: bool,
     testing_intensity: str = "standard",
     anonymized_routing_requested: bool = False,
+    in_scope_assets: list[str] | None = None,
+    out_of_scope_assets: list[str] | None = None,
+    authenticated_testing_allowed: bool = False,
+    production_target: bool = True,
+    primary_stack: list[str] | None = None,
 ) -> str:
     """Create a safe, defensive assessment plan with strict authorization gating."""
     if not authorization_confirmed:
@@ -50,6 +114,10 @@ def cybersecurity_assessment_blueprint_impl(
             "3. Run internal hardening checks using CIS benchmarks and OWASP ASVS.\n"
             "4. Schedule a formal authorized pentest with signed rules of engagement."
         )
+
+    in_scope_assets = in_scope_assets or []
+    out_of_scope_assets = out_of_scope_assets or []
+    primary_stack = primary_stack or []
 
     routing_guidance = (
         "Use transparent, auditable routing from approved tester infrastructure."
@@ -67,27 +135,64 @@ def cybersecurity_assessment_blueprint_impl(
         "careful_active": "Careful active validation in maintenance window with rollback plan.",
     }
 
+    auth_mode = (
+        "Use approved least-privileged test accounts to increase vulnerability coverage "
+        "for authorization, session handling, and access-control testing."
+        if authenticated_testing_allowed
+        else "Unauthenticated-only testing. Expect reduced coverage for access-control issues."
+    )
+
+    environment_controls = (
+        "Production target detected: enforce strict rate limits, maintenance window, and live monitoring."
+        if production_target
+        else "Non-production target: broader validation depth is possible with change control."
+    )
+
+    stack_focus = ", ".join(primary_stack) if primary_stack else "Not specified"
+    in_scope = ", ".join(in_scope_assets) if in_scope_assets else "Not provided"
+    out_scope = ", ".join(out_of_scope_assets) if out_of_scope_assets else "Not provided"
+
     return (
         f"# Authorized Security Assessment Blueprint\n"
         f"- Target: {target}\n"
         f"- Objective: {objective}\n"
         f"- Testing profile: {testing_intensity}\n\n"
+        "## Scope Declaration\n"
+        f"- In scope: {in_scope}\n"
+        f"- Out of scope: {out_scope}\n"
+        f"- Primary stack: {stack_focus}\n"
+        f"- Authenticated testing: {'Yes' if authenticated_testing_allowed else 'No'}\n"
+        f"- Environment: {'Production' if production_target else 'Non-production'}\n\n"
         "## Guardrails\n"
         "- Execute only within signed scope and approved schedule.\n"
         "- No persistence, no privilege escalation attempts, no denial-of-service actions.\n"
+        "- Never collect, retrieve, or disclose plaintext passwords or reusable secrets.\n"
         "- Capture evidence safely and redact personal or regulated data.\n\n"
+        "## Coverage and Effectiveness Controls\n"
+        f"- {auth_mode}\n"
+        f"- {environment_controls}\n"
+        "- Track test coverage by vulnerability family to reduce blind spots.\n"
+        "- Require reproducible proof for each finding and at least one false-positive check.\n"
+        "- Map validated findings to OWASP ASVS/CWE to improve remediation precision.\n\n"
         "## Routing & Identity\n"
         f"- {routing_guidance}\n\n"
         "## Recommended Workflow\n"
         "1. Pre-engagement: validate scope, contacts, backups, and monitoring thresholds.\n"
         f"2. Discovery: {intensity_controls.get(testing_intensity, intensity_controls['standard'])}\n"
-        "3. Validation: confirm findings with reproducible low-risk checks.\n"
+        "3. Validation: confirm findings with reproducible low-risk checks and confidence rating.\n"
         "4. Reporting: assign severity (CVSS), business impact, and remediation owner.\n"
         "5. Retest: verify fixes and close findings with evidence.\n\n"
+        "## Vulnerability Coverage Matrix\n"
+        "1. Identity and access: authn/authz flaws, session controls, MFA bypass paths.\n"
+        "2. Input and API security: injection, SSRF, deserialization, schema validation gaps.\n"
+        "3. Data protection: weak crypto, insecure transport, sensitive data exposure.\n"
+        "4. Infrastructure posture: exposed services, TLS weaknesses, cloud misconfiguration.\n"
+        "5. Supply chain and secrets: vulnerable dependencies, leaked keys, CI/CD exposure.\n\n"
         "## Suggested Defensive Tooling\n"
         "- Surface mapping: amass (authorized), asset inventory, DNS change monitoring.\n"
         "- Web checks: OWASP ZAP baseline scan, Nuclei safe templates, SSLyze.\n"
-        "- Hardening: dependency scanning, secret scanning, MFA and rate-limit validation."
+        "- Hardening: dependency scanning, secret scanning, MFA and rate-limit validation.\n"
+        "- IaC/Cloud: Checkov or tfsec, CSPM controls, IAM policy analyzers."
     )
 
 
@@ -95,20 +200,49 @@ def cybersecurity_generate_report_impl(
     target: str,
     summary: str,
     findings_markdown: str,
+    overall_risk_rating: str = "medium",
+    retest_required_within_days: int = 30,
+    credential_exposure_observed: bool = False,
+    credential_evidence_markdown: str = "",
 ) -> str:
     """Generate an executive + technical report template from provided findings."""
+    if _contains_plaintext_passwords(credential_evidence_markdown):
+        return (
+            "Refused: report input appears to contain plaintext credentials. "
+            "Provide only redacted or non-reusable evidence (masked values, hash presence, "
+            "access logs, and proof-of-impact without secret disclosure)."
+        )
+
+    credential_section = "## Credential Exposure Evidence\n- Not observed during this assessment.\n\n"
+    if credential_exposure_observed:
+        evidence = credential_evidence_markdown.strip() or (
+            "- Evidence required: add redacted proof such as masked sample output, "
+            "hash identifier, impacted endpoint, and remediation recommendation."
+        )
+        credential_section = (
+            "## Credential Exposure Evidence\n"
+            "- Status: Observed (redacted evidence only).\n"
+            f"{evidence}\n\n"
+        )
+
     return (
         f"# Security Assessment Report\n\n"
         f"## Target\n{target}\n\n"
         f"## Executive Summary\n{summary}\n\n"
+        f"## Overall Risk Rating\n{overall_risk_rating.capitalize()}\n\n"
         "## Findings\n"
         f"{findings_markdown}\n\n"
+        f"{credential_section}"
+        "## Validation Quality Standard\n"
+        "- Every finding should include severity, confidence, impacted asset, evidence, and reproduction notes.\n"
+        "- Mark findings as `Needs Verification` when confidence is low to prevent noisy remediation work.\n"
+        "- Evidence must never contain plaintext passwords or reusable secrets.\n\n"
         "## Remediation Program\n"
         "1. Fix internet-exposed critical issues within 24-72 hours.\n"
         "2. Add compensating controls (WAF rules, rate limits, temporary ACLs).\n"
         "3. Improve detection (SIEM alerts, anomaly detection, auth abuse alerts).\n"
         "4. Introduce security tests in CI/CD (SAST, dependency, IaC, and secret scans).\n"
-        "5. Run a scoped retest and document residual risk accepted by stakeholders.\n\n"
+        f"5. Run a scoped retest within {retest_required_within_days} days and document residual risk accepted by stakeholders.\n\n"
         "## Prevention Checklist\n"
         "- Enforce MFA for admin paths and VPN.\n"
         "- Apply least privilege and short-lived credentials.\n"
@@ -131,6 +265,9 @@ def register_tools(registry: ToolRegistry) -> None:
 
     registry.register(
         name="cybersecurity_generate_report",
-        description="Create a structured remediation-focused security report.",
+        description=(
+            "Create a structured remediation-focused security report with redacted "
+            "credential-exposure evidence handling."
+        ),
         args_schema=ReportSchema,
     )(cybersecurity_generate_report_impl)


### PR DESCRIPTION
### Motivation
- Improve defensive assessment quality by adding explicit scoping, authenticated testing options, and stack-aware guidance.
- Prevent accidental disclosure of secrets by detecting and refusing plaintext credentials in evidence and reports.
- Provide clearer, auditable blueprints and better-aligned reporting (risk rating, retest deadlines, and validation quality standards).

### Description
- Expanded `AssessmentBlueprintSchema` and `ReportSchema` with fields like `in_scope_assets`, `out_of_scope_assets`, `authenticated_testing_allowed`, `primary_stack`, `overall_risk_rating`, `retest_required_within_days`, and credential-related flags and evidence fields.
- Implemented `_contains_plaintext_passwords` to heuristically detect plaintext credential disclosures and refuse report generation when such data appears.
- Updated `cybersecurity_assessment_blueprint_impl` to include scope declaration, environment/auth guidance, vulnerability coverage matrix, and stronger guardrails against collecting plaintext secrets.
- Updated `cybersecurity_generate_report_impl` to add overall risk rating, credential exposure handling with redaction rules, validation quality standards, and configurable retest deadline.

### Testing
- No automated tests were added or executed as part of this change; changes are limited to API/schema additions and string-generation logic and should be covered by existing CI if present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ecf87dbbc8333b8009d505dd90d90)