### PR TITLE
Improve scheduler extensibility and add hardened Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+venv
+__pycache__
+*.pyc
+node_modules
+client/node_modules
+client/dist
+docs/_build
+logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+RUN groupadd --system freja && useradd --system --gid freja --create-home --home-dir /home/freja freja
+
+COPY --chown=freja:freja . .
+
+RUN mkdir -p /app/db /app/logs && chown -R freja:freja /app/db /app/logs
+
+USER freja
+
+EXPOSE 8000
+
+CMD ["python", "-m", "uvicorn", "main:app_socketio", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ sudo systemctl enable --now freja.service
 sudo systemctl enable --now freja-vault-unseal.service
 ```
 
+
+## Scheduler API (admin)
+
+The scheduler now supports both instruction tasks and named processes. All endpoints below require admin access.
+
+- `GET /api/scheduler/processes` – list available process handlers.
+- `GET /api/scheduler/tasks` – list all scheduled jobs.
+- `POST /api/scheduler/tasks/instruction` – schedule an instruction with body:
+  ```json
+  {"instruction": "Check backups", "cron": "0 7 * * *"}
+  ```
+- `POST /api/scheduler/tasks/process` – schedule a named process with body:
+  ```json
+  {"process_name": "log_instruction", "cron": "*/15 * * * *", "payload": {"message": "Heartbeat"}}
+  ```
+- `DELETE /api/scheduler/tasks/{job_id}` – delete an existing job.
+
 ## Running the project
 
 ### Option A: Start backend + frontend together (recommended for development)
@@ -212,6 +229,30 @@ cd ..
 ```
 
 Then run backend normally; FastAPI serves static files from `client/dist` if the build exists.
+
+
+## Docker (isolated runtime)
+
+A hardened container setup is included:
+
+- Non-root runtime user (`freja`)
+- Dropped Linux capabilities (`cap_drop: [ALL]`)
+- `no-new-privileges` enabled
+- Read-only root filesystem with writable `db/` and `logs/` mounts
+- `/tmp` mounted as `tmpfs`
+- Health check against `/health`
+
+Run with:
+
+```bash
+docker compose up --build -d
+```
+
+Stop with:
+
+```bash
+docker compose down
+```
 
 ## Health check
 

--- a/app/routers/system.py
+++ b/app/routers/system.py
@@ -5,6 +5,7 @@ import sys
 import logging
 
 from fastapi import APIRouter, BackgroundTasks, Depends
+from pydantic import BaseModel, Field
 
 from app.core.dependencies import get_garmin, get_strava, get_code_executor
 from app.core.security import require_admin
@@ -12,6 +13,19 @@ from skills._core.skill_loader import discover_skill_manifests
 
 logger = logging.getLogger(__name__)
 router = APIRouter(dependencies=[Depends(require_admin)])
+
+
+
+class ScheduleInstructionRequest(BaseModel):
+    instruction: str = Field(..., min_length=1, description="Instruction to run on schedule")
+    cron: str = Field(..., min_length=9, description="Cron expression in crontab format")
+
+
+class ScheduleProcessRequest(BaseModel):
+    process_name: str = Field(..., min_length=1, description="Registered process name")
+    cron: str = Field(..., min_length=9, description="Cron expression in crontab format")
+    payload: dict = Field(default_factory=dict, description="Optional process payload")
+
 
 
 @router.post("/api/self_update")
@@ -166,6 +180,50 @@ async def get_system_logs(limit: int = 100):
     except Exception as e:
         logger.error(f"Error reading journalctl logs: {e}")
         return {"error": str(e), "logs": []}
+
+
+
+@router.get("/api/scheduler/processes")
+async def list_scheduler_processes():
+    """Return all scheduler process handlers that can be scheduled."""
+    from app.services.scheduler_service import scheduler_service
+
+    return {"processes": scheduler_service.list_registered_processes()}
+
+
+@router.get("/api/scheduler/tasks")
+async def list_scheduler_tasks():
+    """Return all currently scheduled jobs."""
+    from app.services.scheduler_service import scheduler_service
+
+    return {"tasks": scheduler_service.list_tasks()}
+
+
+@router.post("/api/scheduler/tasks/instruction")
+async def create_instruction_task(body: ScheduleInstructionRequest):
+    """Create or replace a scheduled instruction task."""
+    from app.services.scheduler_service import scheduler_service
+
+    job_id = scheduler_service.add_task(body.instruction, body.cron)
+    return {"success": True, "job_id": job_id}
+
+
+@router.post("/api/scheduler/tasks/process")
+async def create_process_task(body: ScheduleProcessRequest):
+    """Create or replace a scheduled named process."""
+    from app.services.scheduler_service import scheduler_service
+
+    job_id = scheduler_service.add_process_task(body.process_name, body.cron, body.payload)
+    return {"success": True, "job_id": job_id}
+
+
+@router.delete("/api/scheduler/tasks/{job_id}")
+async def delete_scheduler_task(job_id: str):
+    """Delete a scheduled job by ID."""
+    from app.services.scheduler_service import scheduler_service
+
+    scheduler_service.remove_task(job_id)
+    return {"success": True, "job_id": job_id}
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/scheduler_service.py
+++ b/app/services/scheduler_service.py
@@ -1,82 +1,124 @@
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
-from apscheduler.triggers.cron import CronTrigger
+from __future__ import annotations
+
+import json
 import logging
-import asyncio
-from typing import List, Dict, Any
-from app.core import dependencies
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
 
 logger = logging.getLogger(__name__)
 
+ProcessHandler = Callable[[Dict[str, Any]], Awaitable[None]]
+
+
 class SchedulerService:
-    def __init__(self, db_url="sqlite:///jobs.sqlite"):
-        self.jobstores = {
-            'default': SQLAlchemyJobStore(url=db_url)
-        }
-        self.scheduler = AsyncIOScheduler(jobstores=self.jobstores)
+    def __init__(self, db_url: str = "sqlite:///jobs.sqlite"):
+        self.jobstores = {"default": SQLAlchemyJobStore(url=db_url)}
+        self.scheduler = AsyncIOScheduler(jobstores=self.jobstores, timezone="UTC")
+        self._process_handlers: Dict[str, ProcessHandler] = {}
+        self.register_process("log_instruction", self._default_log_process)
         self.scheduler.start()
-        logger.info("Scheduler Service started.")
+        logger.info("Scheduler service started")
+
+    def register_process(self, process_name: str, handler: ProcessHandler) -> None:
+        """Register a new process handler that can be scheduled by name."""
+        normalized = process_name.strip().lower()
+        if not normalized:
+            raise ValueError("process_name must not be empty")
+        self._process_handlers[normalized] = handler
+        logger.info("Registered scheduler process '%s'", normalized)
+
+    def list_registered_processes(self) -> List[str]:
+        return sorted(self._process_handlers.keys())
 
     def add_task(self, instruction: str, cron_expression: str) -> str:
-        """
-        Schedules a task.
-        Cron expression format: "minute hour day month day_of_week"
-        (Standard cron formatting, but we can also parse simpler strings if needed)
-        """
-        # Parse cron string loosely or use standard format? 
-        # For simplicity, let's assume '*/5 * * * *' format or keywords.
-        # Actually APScheduler provides a robust trigger.
-        
-        # We need a function to execute.
-        # It must be picklable or importable.
-        # So we define a standalone function in this module or use a static method.
-        
+        """Schedule a standard instruction-based task."""
+        instruction = instruction.strip()
+        if not instruction:
+            raise ValueError("instruction must not be empty")
+
+        trigger = CronTrigger.from_crontab(cron_expression)
+        job_id = f"instruction:{abs(hash((instruction, cron_expression)))}"
         job = self.scheduler.add_job(
             execute_scheduled_task,
-            CronTrigger.from_crontab(cron_expression),
+            trigger,
             args=[instruction],
-            name=instruction
+            id=job_id,
+            name=instruction,
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+            misfire_grace_time=300,
+        )
+        return job.id
+
+    def add_process_task(
+        self,
+        process_name: str,
+        cron_expression: str,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Schedule a named process task with JSON payload."""
+        normalized = process_name.strip().lower()
+        if normalized not in self._process_handlers:
+            raise ValueError(f"Unknown process: {process_name}")
+
+        trigger = CronTrigger.from_crontab(cron_expression)
+        serialized_payload = json.dumps(payload or {}, ensure_ascii=False)
+        job_id = f"process:{normalized}:{abs(hash((normalized, cron_expression, serialized_payload)))}"
+        job = self.scheduler.add_job(
+            execute_named_process,
+            trigger,
+            args=[normalized, serialized_payload],
+            id=job_id,
+            name=f"process:{normalized}",
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+            misfire_grace_time=300,
         )
         return job.id
 
     def list_tasks(self) -> List[Dict[str, Any]]:
         jobs = self.scheduler.get_jobs()
-        return [{"id": j.id, "name": j.name, "next_run": str(j.next_run_time)} for j in jobs]
+        return [
+            {
+                "id": job.id,
+                "name": job.name,
+                "next_run": str(job.next_run_time),
+                "trigger": str(job.trigger),
+            }
+            for job in jobs
+        ]
 
-    def remove_task(self, job_id: str):
+    def remove_task(self, job_id: str) -> None:
         self.scheduler.remove_job(job_id)
+
+    async def _default_log_process(self, payload: Dict[str, Any]) -> None:
+        message = payload.get("message", "No payload message provided")
+        logger.info("Scheduled process [log_instruction]: %s", message)
+
 
 scheduler_service = SchedulerService()
 
-async def execute_scheduled_task(instruction: str):
-    """
-    The function that actually runs when the timer fires.
-    It needs to spawn a 'Chat' context effectively.
-    """
-    logger.info(f"Executing scheduled task: {instruction}")
-    
-    # We need to trigger the LLM to 'do' the task.
-    # We can reuse the ChatService logic, but we need to verify dependencies aren't circular.
+
+async def execute_scheduled_task(instruction: str) -> None:
+    """Execute a scheduled instruction task."""
+    logger.info("Executing scheduled task: %s", instruction)
     try:
-        # Import here to avoid circular imports during startup
-        from app.services.chat_service import ChatService
-        from app.core.config import settings
-        # We need a dummy user_id or system id?
-        
-        # Ideally, we inject a "System Message" with the instruction.
-        # "It is time to perform this scheduled task: {instruction}"
-        
-        # For now, let's just log it to prove it works.
-        # Implementing full autonomous execution requires a user session or a "system" session.
-        print(f"⏰ [SCHEDULER] Running: {instruction}")
-        
-        # REAL IMPLEMENTATION (Commented until ChatService is ready for headless mode)
-        # chat_service = dependencies.get_chat_service() 
-        # response = await chat_service.process_message(
-        #    message=f"SYSTEM TRIGGER: Execute this scheduled task: {instruction}",
-        #    model="gemini-2.0-flash", 
-        #    user_id="system"
-        # )
-        
-    except Exception as e:
-        logger.error(f"Task execution failed: {e}")
+        print(f"⏰ [SCHEDULER] Running instruction: {instruction}")
+    except Exception as exc:
+        logger.error("Task execution failed: %s", exc)
+
+
+async def execute_named_process(process_name: str, serialized_payload: str) -> None:
+    """Execute a process previously registered in SchedulerService."""
+    logger.info("Executing scheduled process: %s", process_name)
+    try:
+        payload = json.loads(serialized_payload) if serialized_payload else {}
+        handler = scheduler_service._process_handlers[process_name]
+        await handler(payload)
+    except Exception as exc:
+        logger.error("Scheduled process '%s' failed: %s", process_name, exc)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  freja:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: freja-app
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    environment:
+      PYTHONUNBUFFERED: "1"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+    volumes:
+      - ./db:/app/db:rw
+      - ./logs:/app/logs:rw
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s

--- a/skills/scheduler/tools.py
+++ b/skills/scheduler/tools.py
@@ -1,74 +1,133 @@
-from app.services.tool_registry import ToolRegistry
-from pydantic import BaseModel, Field
-from app.services.scheduler_service import scheduler_service
+import json
 import logging
+from typing import Any, Dict
+
+from pydantic import BaseModel, Field
+
+from app.services.scheduler_service import scheduler_service
+from app.services.tool_registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-# --- Schemas ---
 
 class ScheduleTaskSchema(BaseModel):
-    instruction: str = Field(..., description="The instruction/task for Freja to perform (e.g., 'Check server status').")
-    cron: str = Field(..., description="Cron expression for the schedule (e.g., '0 8 * * *' for daily at 08:00).")
+    instruction: str = Field(..., description="Instruction for Freja to perform (for example, 'Check server status').")
+    cron: str = Field(..., description="Cron expression (for example, '0 8 * * *' for every day at 08:00).")
+
+
+class ScheduleProcessSchema(BaseModel):
+    process_name: str = Field(..., description="Registered process name to execute on schedule.")
+    cron: str = Field(..., description="Cron expression (for example, '*/15 * * * *').")
+    payload: Dict[str, Any] = Field(default_factory=dict, description="Optional JSON payload passed to the process.")
+
 
 class DeleteTaskSchema(BaseModel):
-    job_id: str = Field(..., description="The ID of the job to remove.")
+    job_id: str = Field(..., description="ID of the job to remove.")
+
 
 class ListTasksSchema(BaseModel):
     pass
 
-# --- Implementations ---
+
+class ListProcessesSchema(BaseModel):
+    pass
+
 
 def schedule_task_impl(instruction: str, cron: str) -> str:
-    """Schedules a new task for Freja to perform."""
+    """Schedule a new instruction-based task."""
     try:
         job_id = scheduler_service.add_task(instruction, cron)
-        return f"Task '{instruction}' scheduled with ID: {job_id} (Cron: {cron})"
-    except Exception as e:
-        logger.error(f"Failed to schedule task: {e}")
-        return f"Error scheduling task: {e}"
+        return f"Task '{instruction}' scheduled with ID: {job_id} (cron: {cron})"
+    except Exception as exc:
+        logger.error("Failed to schedule task: %s", exc)
+        return f"Error scheduling task: {exc}"
+
+
+def schedule_process_impl(process_name: str, cron: str, payload: Dict[str, Any]) -> str:
+    """Schedule a process by name with optional JSON payload."""
+    try:
+        job_id = scheduler_service.add_process_task(process_name, cron, payload)
+        serialized_payload = json.dumps(payload, ensure_ascii=False)
+        return (
+            f"Process '{process_name}' scheduled with ID: {job_id} "
+            f"(cron: {cron}, payload: {serialized_payload})"
+        )
+    except Exception as exc:
+        logger.error("Failed to schedule process '%s': %s", process_name, exc)
+        return f"Error scheduling process: {exc}"
+
 
 def list_tasks_impl() -> str:
-    """Lists all scheduled tasks."""
+    """List all scheduled tasks."""
     try:
         tasks = scheduler_service.list_tasks()
         if not tasks:
             return "No scheduled tasks found."
-        
+
         output = "### Scheduled Tasks\n"
-        for t in tasks:
-            output += f"- **ID**: `{t['id']}`\n  **Task**: {t['name']}\n  **Next Run**: {t['next_run']}\n"
+        for task in tasks:
+            output += (
+                f"- **ID**: `{task['id']}`\n"
+                f"  **Task**: {task['name']}\n"
+                f"  **Trigger**: {task['trigger']}\n"
+                f"  **Next Run**: {task['next_run']}\n"
+            )
         return output
-    except Exception as e:
-        logger.error(f"Failed to list tasks: {e}")
-        return f"Error listing tasks: {e}"
+    except Exception as exc:
+        logger.error("Failed to list tasks: %s", exc)
+        return f"Error listing tasks: {exc}"
+
+
+def list_processes_impl() -> str:
+    """List all registered scheduler process handlers."""
+    try:
+        processes = scheduler_service.list_registered_processes()
+        if not processes:
+            return "No registered scheduler processes found."
+        process_rows = "\n".join(f"- `{name}`" for name in processes)
+        return f"### Registered Scheduler Processes\n{process_rows}"
+    except Exception as exc:
+        logger.error("Failed to list registered processes: %s", exc)
+        return f"Error listing registered processes: {exc}"
+
 
 def delete_task_impl(job_id: str) -> str:
-    """Removes a scheduled task."""
+    """Delete a scheduled task."""
     try:
         scheduler_service.remove_task(job_id)
         return f"Task {job_id} deleted."
-    except Exception as e:
-        logger.error(f"Failed to delete task: {e}")
-        return f"Error deleting task: {e}"
+    except Exception as exc:
+        logger.error("Failed to delete task: %s", exc)
+        return f"Error deleting task: {exc}"
 
-# --- Registration ---
 
 def register_tools(registry: ToolRegistry) -> None:
     registry.register(
         name="schedule_autonomous_task",
-        description="Schedule a task for Freja to perform automatically at specific times. Use standard cron format.",
+        description="Schedule an instruction task for Freja using cron format.",
         args_schema=ScheduleTaskSchema,
     )(schedule_task_impl)
 
     registry.register(
+        name="schedule_named_process",
+        description="Schedule a named process with optional JSON payload.",
+        args_schema=ScheduleProcessSchema,
+    )(schedule_process_impl)
+
+    registry.register(
         name="list_scheduled_tasks",
-        description="List all currently scheduled autonomous tasks.",
-        args_schema=ListTasksSchema, # No args
+        description="List all scheduled autonomous tasks.",
+        args_schema=ListTasksSchema,
     )(list_tasks_impl)
-    
+
+    registry.register(
+        name="list_scheduler_processes",
+        description="List all registered scheduler processes that can be scheduled.",
+        args_schema=ListProcessesSchema,
+    )(list_processes_impl)
+
     registry.register(
         name="delete_scheduled_task",
-        description="Delete a scheduled task by its ID.",
+        description="Delete a scheduled task by ID.",
         args_schema=DeleteTaskSchema,
     )(delete_task_impl)


### PR DESCRIPTION
### Motivation
- Make the scheduler extensible so operators can register and schedule named processes with JSON payloads in addition to simple instruction jobs.
- Improve reliability of scheduled jobs by using safer APScheduler options and clearer job metadata for inspection.
- Provide a hardened, isolated Docker runtime so the service can be deployed with reduced privileges and explicit writable mounts.

### Description
- Refactored `SchedulerService` to add `register_process`, `list_registered_processes`, `add_process_task`, a built-in `log_instruction` handler, and `execute_named_process`, while keeping existing instruction scheduling via `add_task` intact.
- Hardened job scheduling options with `replace_existing=True`, `max_instances=1`, `coalesce=True`, `misfire_grace_time=300`, deterministic job IDs, and enriched `list_tasks` metadata (`trigger`, `next_run`).
- Extended scheduler skill tooling in `skills/scheduler/tools.py` with `schedule_named_process`, `list_scheduler_processes`, improved `list_scheduled_tasks` output, and preserved `schedule_autonomous_task`/`delete_scheduled_task` behavior.
- Added admin HTTP endpoints in `app/routers/system.py` to list processes and tasks and to create/delete jobs: `GET /api/scheduler/processes`, `GET /api/scheduler/tasks`, `POST /api/scheduler/tasks/instruction`, `POST /api/scheduler/tasks/process`, and `DELETE /api/scheduler/tasks/{job_id}`.
- Added a hardened container setup: new `Dockerfile`, `docker-compose.yml` with `no-new-privileges`, `cap_drop: ALL`, read-only rootfs, `tmpfs` for `/tmp`, explicit `db` and `logs` mounts, and a `.dockerignore`, and updated `README.md` with scheduler and Docker usage notes.

### Testing
- Ran `python -m py_compile app/services/scheduler_service.py skills/scheduler/tools.py app/routers/system.py` and compilation succeeded.
- Ran the repository script `./scripts/verify_python_compile.sh` and it passed the repository-wide Python compile check.
- Attempted `docker compose config` to validate compose; the check failed in the environment because the Docker CLI is not available (no runtime failure in code itself).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6bac9bbf08333b65ac5fcc80ac41a)