### PR TITLE
Add Fitbit integration skill for health and activity retrieval

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -79,6 +79,11 @@ class Settings(BaseSettings):
     WITHINGS_REDIRECT_URI: Optional[str] = None
     WITHINGS_REFRESH_TOKEN: Optional[str] = None
 
+    FITBIT_CLIENT_ID: Optional[str] = None
+    FITBIT_CLIENT_SECRET: Optional[str] = None
+    FITBIT_REDIRECT_URI: Optional[str] = None
+    FITBIT_REFRESH_TOKEN: Optional[str] = None
+
     MQTT_BROKER_IP: str = "127.0.0.1"
     MQTT_PORT: int = 1883
     MQTT_TOPIC_BASE: str = "zigbee2mqtt"

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -12,6 +12,7 @@ class DependencyManager:
         self._garmin_tool = None
         self._strava_tool = None
         self._withings_tool = None
+        self._fitbit_tool = None
         self._code_executor = None
         self._has_docker = False
 
@@ -75,6 +76,25 @@ class DependencyManager:
 
         return self._withings_tool
 
+
+    def get_fitbit_tool(self):
+        if self._fitbit_tool:
+            return self._fitbit_tool
+
+        fitbit_client_id = get_credential("FITBIT_CLIENT_ID")
+        fitbit_client_secret = get_credential("FITBIT_CLIENT_SECRET")
+
+        if fitbit_client_id and fitbit_client_secret:
+            try:
+                from skills.fitbit.core import FitbitTool
+
+                self._fitbit_tool = FitbitTool()
+                logger.info("Fitbit tool initialized (Dependency)")
+            except Exception as exc:
+                logger.error(f"Fitbit init failed: {exc}")
+
+        return self._fitbit_tool
+
     def get_code_executor(self):
         if self._code_executor:
             return self._code_executor
@@ -116,3 +136,7 @@ def get_withings():
 
 def get_code_executor():
     return _manager.get_code_executor()
+
+
+def get_fitbit():
+    return _manager.get_fitbit_tool()

--- a/app/core/tool_registry.py
+++ b/app/core/tool_registry.py
@@ -7,6 +7,7 @@ from app.core.config import settings
 # Import tool classes
 from skills.garmin.core import GarminCoach
 from skills.strava.core import StravaTool
+from skills.fitbit.core import FitbitTool
 from skills.deep_research.core import WebAgent
 
 class ToolRegistry:
@@ -33,7 +34,15 @@ class ToolRegistry:
             except Exception as e:
                 logger.error(f"Strava init failed: {e}")
 
-        # 3. Web Agent (Computer Use)
+        # 3. Fitbit
+        if settings.FITBIT_CLIENT_ID and settings.FITBIT_REFRESH_TOKEN:
+            try:
+                self.tools["fitbit"] = FitbitTool()
+                logger.info("Fitbit tool initialized")
+            except Exception as e:
+                logger.error(f"Fitbit init failed: {e}")
+
+        # 4. Web Agent (Computer Use)
         # Vi initierar denna om GEMINI_API_KEY finns, vilket web_core.py kollar internt
         try:
             self.tools["web_agent"] = WebAgent()
@@ -60,7 +69,8 @@ class ToolRegistry:
         # Cache durations (in seconds)
         durations = {
             "garmin": 900,  # 15 mins
-            "strava": 300   # 5 mins
+            "strava": 300,  # 5 mins
+            "fitbit": 600,  # 10 mins
         }
         duration = durations.get(tool_name, 300)
 
@@ -77,6 +87,8 @@ class ToolRegistry:
                 data = await asyncio.to_thread(tool.get_health_report)
             elif tool_name == "strava":
                 data = await tool.get_health_report(limit=1)
+            elif tool_name == "fitbit":
+                data = await tool.get_health_report(activities_limit=3)
             else:
                 data = None
 
@@ -128,6 +140,15 @@ class ToolRegistry:
             if data:
                 data_str = json.dumps(data, indent=2, ensure_ascii=False)
                 injection += f"\n\n[SENASTE TRÄNINGSPASS FRÅN STRAVA]:\n{data_str}\n\nINSTRUKTION: Använd denna data för att svara detaljerat om träningen."
+
+        # Fitbit Logic
+        fitbit_triggers = ["fitbit", "daily activity", "sleep score", "active zone", "resting heart rate"]
+        if any(t in text_lower for t in fitbit_triggers):
+            logger.info("Fitbit trigger matched")
+            data = await self.get_tool_data("fitbit")
+            if data:
+                data_str = json.dumps(data, indent=2, ensure_ascii=False)
+                injection += f"\n\n[FITBIT HEALTH SUMMARY]:\n{data_str}\n\nINSTRUCTION: Use Fitbit data when giving health and activity guidance."
 
         return injection
     

--- a/app/routers/integrations.py
+++ b/app/routers/integrations.py
@@ -3,7 +3,7 @@ from app.core import config
 import logging
 
 # Skill helpers
-from app.core.dependencies import get_withings
+from app.core.dependencies import get_withings, get_fitbit
 from skills.strava import get_strava_command_processor
 from skills.homeassistant.homeassistant_skill import get_homeassistant_command_processor
 from app.core.security import require_admin
@@ -74,5 +74,21 @@ async def test_withings():
              return {"success": True, "message": "Configuration valid. Click 'Connect' to authenticate."}
         else:
              return {"success": False, "message": "Configuration missing."}
+    except Exception as e:
+        return {"success": False, "message": str(e)}
+
+
+@router.post("/api/integrations/fitbit/test")
+async def test_fitbit():
+    try:
+        fitbit = get_fitbit()
+        if not fitbit:
+            return {"success": False, "message": "Fitbit tool not initialized."}
+
+        if config.get_credential("FITBIT_REFRESH_TOKEN"):
+            return {"success": True, "message": "Fitbit configuration and refresh token found."}
+        if config.get_credential("FITBIT_CLIENT_ID"):
+            return {"success": True, "message": "Fitbit configuration is valid. Complete OAuth to add refresh token."}
+        return {"success": False, "message": "Fitbit configuration missing."}
     except Exception as e:
         return {"success": False, "message": str(e)}

--- a/skills/README.md
+++ b/skills/README.md
@@ -27,6 +27,7 @@ Freja decides when to call the underlying tool automatically.
 - `codex` – code execution, Git operations, and codebase auditing.
 - `cybersecurity` – authorization-gated defensive security assessment planning and reporting.
 - `garmin` – health snapshot from Garmin Connect.
+- `fitbit` – daily Fitbit activity, sleep, and heart-rate summaries.
 - `google_calendar` – list/create/update/delete calendar events.
 - `homeassistant` – smart-home control via Home Assistant API.
 - `pfsense` – firewall/system log analysis via pfrest.

--- a/skills/_core/definitions.py
+++ b/skills/_core/definitions.py
@@ -42,6 +42,12 @@ class GetWithingsHealth(BaseModel):
     pass
 
 
+class GetFitbitHealth(BaseModel):
+    """Retrieve Fitbit health metrics and recent activities for the current user."""
+
+    activities_limit: int = Field(5, description="The maximum number of recent Fitbit activities to return. Defaults to 5.")
+
+
 class RoborockConfigure(BaseModel):
     """Configure Roborock integration credentials and optional default device."""
 

--- a/skills/fitbit/README.md
+++ b/skills/fitbit/README.md
@@ -1,0 +1,14 @@
+# Fitbit Skill
+
+This skill provides a `get_fitbit_health` tool for daily Fitbit data.
+
+## Required settings
+
+- `FITBIT_CLIENT_ID`
+- `FITBIT_CLIENT_SECRET`
+- `FITBIT_REFRESH_TOKEN`
+
+## Tool
+
+- `get_fitbit_health(activities_limit=5)`
+  - Returns daily summary (steps, calories, active-zone minutes, resting HR), sleep summary, and recent activities.

--- a/skills/fitbit/__init__.py
+++ b/skills/fitbit/__init__.py
@@ -1,0 +1,20 @@
+"""Fitbit skill package for Freja.io."""
+
+from skills._core.skill_types import SkillManifest
+from skills.fitbit.tools import register_tools
+
+
+SKILL = SkillManifest(
+    name="fitbit",
+    description="Provides Fitbit health and activity reporting tools.",
+    version="1.0.0",
+    tools=["get_fitbit_health"],
+)
+
+
+def register(registry) -> None:
+    """Register all tools provided by the Fitbit skill."""
+    register_tools(registry)
+
+
+__all__ = ["SKILL", "register"]

--- a/skills/fitbit/core.py
+++ b/skills/fitbit/core.py
@@ -1,0 +1,133 @@
+"""Core Fitbit client used by the Fitbit skill."""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import time
+from typing import Any
+
+import httpx
+
+from app.core.config import get_credential
+
+
+class FitbitTool:
+    """Fetch daily Fitbit health and activity data using OAuth refresh tokens."""
+
+    def __init__(self) -> None:
+        self.client_id = get_credential("FITBIT_CLIENT_ID")
+        self.client_secret = get_credential("FITBIT_CLIENT_SECRET")
+        self.refresh_token = get_credential("FITBIT_REFRESH_TOKEN")
+        self.access_token: str | None = None
+        self.expires_at = 0
+
+    async def _refresh_access_token(self) -> bool:
+        """Refresh the Fitbit OAuth access token when needed."""
+        latest_refresh_token = get_credential("FITBIT_REFRESH_TOKEN")
+        if latest_refresh_token != self.refresh_token:
+            self.refresh_token = latest_refresh_token
+            self.access_token = None
+            self.expires_at = 0
+
+        if self.access_token and time.time() < self.expires_at:
+            return True
+
+        if not self.client_id or not self.client_secret or not self.refresh_token:
+            return False
+
+        basic_auth = base64.b64encode(f"{self.client_id}:{self.client_secret}".encode("utf-8")).decode("utf-8")
+        headers = {
+            "Authorization": f"Basic {basic_auth}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": self.refresh_token,
+        }
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post("https://api.fitbit.com/oauth2/token", data=payload, headers=headers)
+
+        if response.status_code != 200:
+            return False
+
+        data = response.json()
+        self.access_token = data.get("access_token")
+        self.refresh_token = data.get("refresh_token", self.refresh_token)
+        expires_in = int(data.get("expires_in", 3600))
+        self.expires_at = time.time() + expires_in - 60
+
+        try:
+            from app.core.vault import save_vault_secret
+
+            save_vault_secret("FITBIT_REFRESH_TOKEN", self.refresh_token)
+        except Exception:
+            # Non-blocking fallback: runtime still works with in-memory token.
+            pass
+
+        return bool(self.access_token)
+
+    async def _fetch_json(self, client: httpx.AsyncClient, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Call a Fitbit API endpoint and return parsed JSON."""
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        response = await client.get(f"https://api.fitbit.com{path}", headers=headers, params=params)
+        if response.status_code != 200:
+            raise RuntimeError(f"Fitbit API error {response.status_code}: {response.text[:200]}")
+        return response.json()
+
+    async def get_health_report(self, activities_limit: int = 5) -> dict[str, Any]:
+        """Return Fitbit daily summary, sleep details, and recent activities."""
+        if not self.refresh_token:
+            return {"error": "No Fitbit refresh token configured."}
+
+        if not await self._refresh_access_token():
+            return {"error": "Could not authenticate with Fitbit. Check credentials and refresh token."}
+
+        today = dt.date.today().isoformat()
+        month_ago = (dt.date.today() - dt.timedelta(days=30)).isoformat()
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                daily_data = await self._fetch_json(client, "/1/user/-/activities/date/today.json")
+                sleep_data = await self._fetch_json(client, "/1.2/user/-/sleep/date/today.json")
+                activities_data = await self._fetch_json(
+                    client,
+                    "/1/user/-/activities/list.json",
+                    params={
+                        "afterDate": month_ago,
+                        "sort": "desc",
+                        "offset": 0,
+                        "limit": max(1, min(activities_limit, 20)),
+                    },
+                )
+
+            summary = daily_data.get("summary", {})
+            sleep_summary = sleep_data.get("summary", {})
+            recent = []
+            for item in activities_data.get("activities", []):
+                recent.append(
+                    {
+                        "name": item.get("activityName"),
+                        "start_time": item.get("startTime"),
+                        "duration_minutes": round((item.get("duration", 0) or 0) / 60000, 1),
+                        "calories": item.get("calories"),
+                        "steps": item.get("steps"),
+                        "distance_km": round((item.get("distance", 0) or 0) / 1000, 2),
+                    }
+                )
+
+            return {
+                "date": today,
+                "steps": summary.get("steps"),
+                "distance_km": round((summary.get("distances", [{}])[0].get("distance", 0) or 0), 2),
+                "calories_out": summary.get("caloriesOut"),
+                "active_zone_minutes": summary.get("activeZoneMinutes", {}),
+                "resting_heart_rate": summary.get("restingHeartRate"),
+                "sleep_total_minutes": sleep_summary.get("totalMinutesAsleep"),
+                "sleep_efficiency": sleep_summary.get("efficiency"),
+                "sleep_stages": sleep_summary.get("stages"),
+                "recent_activities": recent,
+            }
+        except Exception as exc:
+            return {"error": f"Fitbit fetch error: {exc}"}

--- a/skills/fitbit/tools.py
+++ b/skills/fitbit/tools.py
@@ -1,0 +1,33 @@
+"""Fitbit tool registrations exposed by the Fitbit skill."""
+
+import json
+
+from app.core import dependencies
+from app.services.tool_registry import ToolRegistry
+from skills._core.definitions import GetFitbitHealth
+
+
+def register_tools(registry: ToolRegistry) -> None:
+    """Register Fitbit-related tools in the shared tool registry."""
+
+    @registry.register(
+        name="get_fitbit_health",
+        description=(
+            "Fetches Fitbit health data including daily activity totals, sleep metrics, "
+            "heart rate summary, and recent activities."
+        ),
+        args_schema=GetFitbitHealth,
+    )
+    async def get_fitbit_health_impl(activities_limit: int = 5) -> str:
+        fitbit_tool = dependencies.get_fitbit()
+        if not fitbit_tool:
+            return (
+                "Fitbit service is not configured. Add FITBIT_CLIENT_ID, "
+                "FITBIT_CLIENT_SECRET, and FITBIT_REFRESH_TOKEN."
+            )
+
+        data = await fitbit_tool.get_health_report(activities_limit=activities_limit)
+        if isinstance(data, dict) and "error" in data:
+            return data["error"]
+
+        return json.dumps(data, indent=2, ensure_ascii=False)


### PR DESCRIPTION
### Motivation
- Provide a Fitbit integration that mirrors the existing Strava/Garmin/Withings skills so Freja can fetch daily activity, sleep, heart-rate summaries and recent activities from Fitbit.

### Description
- Add a new `skills/fitbit` skill package with `FitbitTool` implementing OAuth refresh and API calls, plus a `get_fitbit_health` tool registration and `skills/fitbit/README.md` documenting required settings.
- Add `GetFitbitHealth` Pydantic schema in `skills/_core/definitions.py` to expose an `activities_limit` argument for the tool.
- Wire Fitbit into dependency management via `get_fitbit()` in `app/core/dependencies.py` so the tool can be lazily initialized like other integrations.
- Integrate Fitbit into the global tool registry and context-injection caching in `app/core/tool_registry.py`, add config entries in `app/core/config.py`, and expose an admin test endpoint `POST /api/integrations/fitbit/test` in `app/routers/integrations.py`.

### Testing
- Ran module compilation with `python -m compileall skills/fitbit app/core/dependencies.py app/core/tool_registry.py app/core/config.py app/routers/integrations.py skills/_core/definitions.py` and the files compiled successfully.
- Verified Python modules import/compile without syntax errors by running the same compile step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe000a33083338c0dd3eb478fb942)